### PR TITLE
Fixed input mangling by MapSets

### DIFF
--- a/lib/cogctl/action.ex
+++ b/lib/cogctl/action.ex
@@ -14,7 +14,7 @@ defmodule Cogctl.Action do
     quote do
       @behaviour unquote(__MODULE__)
 
-      def name(), do: Cogctl.Util.enum_to_set(unquote(pattern))
+      def name(), do: unquote(pattern)
       def display_name, do: unquote(name)
     end
   end

--- a/lib/cogctl/optparse.ex
+++ b/lib/cogctl/optparse.ex
@@ -1,7 +1,5 @@
 defmodule Cogctl.Optparse do
 
-  alias Cogctl.Util
-
   @valid_actions [Cogctl.Actions.Bootstrap,
                   Cogctl.Actions.Profiles,
                   Cogctl.Actions.Bundles,
@@ -54,12 +52,11 @@ defmodule Cogctl.Optparse do
   end
 
   defp parse_action(args) do
-    args = Util.enum_to_set(args)
     handlers = handler_patterns()
     Enum.reduce(handlers, nil,
       fn(%{handler: handler, pattern: pattern}, nil) ->
-        if MapSet.subset?(pattern, args) do
-          {handler, MapSet.difference(args, pattern)}
+        if starts_with?(args, pattern) do
+          {handler, args -- pattern}
         else
           nil
         end
@@ -71,7 +68,7 @@ defmodule Cogctl.Optparse do
     handlers = for handler <- @valid_actions do
       %{handler: handler, pattern: handler.name()}
     end
-    Enum.sort(handlers, &MapSet.size(&1.pattern) > MapSet.size(&2.pattern))
+    Enum.sort(handlers, &(length(&1.pattern) > length(&2.pattern)))
   end
 
   defp display_valid_actions() do
@@ -109,6 +106,16 @@ defmodule Cogctl.Optparse do
   end
   defp ensure_elixir_strings([h|t], accum) do
     ensure_elixir_strings(t, [h|accum])
+  end
+
+  def starts_with?([data|dt], [pattern|pt]) when data == pattern do
+    starts_with?(dt, pt)
+  end
+  def starts_with?(_data, []) do
+    true
+  end
+  def starts_with?(_, _) do
+    false
   end
 
 end

--- a/lib/cogctl/util.ex
+++ b/lib/cogctl/util.ex
@@ -1,7 +1,0 @@
-defmodule Cogctl.Util do
-
-  def enum_to_set(items) do
-    Enum.reduce(items, MapSet.new(), &MapSet.put(&2, &1))
-  end
-
-end


### PR DESCRIPTION
This commit uses raw lists, pattern matching, and the '--' operator to
match actions up with their CLI names and carve those names off of argv
so the remaining args can be parsed per the action's getopt config.

Prior to this commit we used MapSets to do the same thing. MapSets
aren't order preserving so CLI args would get mangled when we attempted
to round trip them list -> MapSet -> list.
