### PR TITLE
Issue #362: Make first and last names optional

### DIFF
--- a/lib/cogctl/actions/users.ex
+++ b/lib/cogctl/actions/users.ex
@@ -9,12 +9,17 @@ defmodule Cogctl.Actions.Users do
   def run(_options, _args, _config, endpoint),
     do: with_authentication(endpoint, &do_list/1)
 
+  defp generate_table_row(username, nil, nil), do: [username, ""]
+  defp generate_table_row(username, first, nil), do: [username, first]
+  defp generate_table_row(username, nil, last), do: [username, last]
+  defp generate_table_row(username, first, last), do: [username, first <> " " <> last]
+
   defp do_list(endpoint) do
     case CogApi.HTTP.Old.user_index(endpoint) do
       {:ok, resp} ->
         users = resp["users"]
         user_attrs = for user <- users do
-          [user["username"], user["first_name"] <> " " <> user["last_name"]]
+          generate_table_row(user["username"], user["first_name"], user["last_name"])
         end
 
         display_output(Table.format([["USERNAME", "FULL NAME"]] ++ user_attrs, true))

--- a/lib/cogctl/actions/users/create.ex
+++ b/lib/cogctl/actions/users/create.ex
@@ -6,16 +6,16 @@ defmodule Cogctl.Actions.Users.Create do
   @params [:first_name, :last_name, :email_address, :username, :password]
 
   def option_spec do
-    [{:first_name, :undefined, 'first-name', {:string, :undefined}, 'First name (required)'},
-     {:last_name, :undefined, 'last-name', {:string, :undefined}, 'Last name (required)'},
+    [{:first_name, :undefined, 'first-name', {:string, :undefined}, 'First name'},
+     {:last_name, :undefined, 'last-name', {:string, :undefined}, 'Last name'},
      {:email_address, :undefined, 'email', {:string, :undefined}, 'Email address (required)'},
      {:username, :undefined, 'username', {:string, :undefined}, 'Username (required)'},
      {:password, :undefined, 'password', {:string, :undefined}, 'Password (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options, [first_name: :required,
-                                         last_name: :required,
+    params = convert_to_params(options, [first_name: :optional,
+                                         last_name: :optional,
                                          email_address: :required,
                                          username: :required,
                                          password: :required])
@@ -34,7 +34,7 @@ defmodule Cogctl.Actions.Users.Create do
         username = user["username"]
 
         user_attrs = for {title, attr} <- [{"ID", "id"}, {"Username", "username"}, {"First Name", "first_name"}, {"Last Name", "last_name"}, {"Email", "email_address"}] do
-          [title, user[attr]]
+          generate_table_row(title, user[attr])
         end
 
         display_output("""
@@ -46,4 +46,7 @@ defmodule Cogctl.Actions.Users.Create do
         display_error(error["errors"])
     end
   end
+
+  defp generate_table_row(title, nil), do: [title, ""]
+  defp generate_table_row(title, attr), do: [title, attr]
 end

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -100,8 +100,29 @@ defmodule CogctlTest do
     Email       jfrost@operable.io
     """
 
+    output = run("""
+    cogctl users create
+      --email=rrobin@operable.io
+      --username=rrobin
+      --password=password
+    """)
+
+    assert output =~ ~r"""
+    Created rrobin
+
+    ID          .*
+    Username    rrobin
+    First Name
+    Last Name
+    Email       rrobin@operable.io
+    """
+
     assert run("cogctl users delete jfrost") =~ ~r"""
     Deleted jfrost
+    """
+
+    assert run("cogctl users delete rrobin") =~ ~r"""
+    Deleted rrobin
     """
   end
 


### PR DESCRIPTION
The first and last names in the User model should be optional fields. If the fields are empty, when they are displayed we should return empty strings. 

Fixes https://github.com/operable/cog/issues/362