### PR TITLE
Provide feedback when authentication fails

### DIFF
--- a/lib/cogctl/action_util.ex
+++ b/lib/cogctl/action_util.ex
@@ -27,6 +27,37 @@ defmodule Cogctl.ActionUtil do
     end
   end
 
+  @doc """
+  Wraps an operation with a call to authenticate against the Cog
+  API. The resulting client (ensured to have a token) will be passed
+  to an arity-1 function that will perform the desired action.
+
+  Any authentication-related error is handled for you; errors that
+  arise within the execution of your function are your
+  responsibility. Authentication errors result in a message being
+  printed to `STDERR`.
+
+  The `api` argument is solely for plugging alternative API
+  implementations for testing purposes, and generally isn't useful
+  outside of that context.
+  """
+  @spec with_authentication(%Cogctl.Profile{}, (%Cogctl.Profile{} -> term), module) :: term
+  def with_authentication(client, fun, api \\ CogApi) do
+    case api.authenticate(client) do
+      {:ok, client_with_token} ->
+        fun.(client_with_token)
+      {:error, error} ->
+        IO.puts(:stderr, """
+        #{error["error"]}
+
+        You can specify appropriate credentials on the command line via
+        the `--user` and `--pw` flags, or set them in your `$HOME/.cogctl`
+        file.
+        """)
+        :error
+    end
+  end
+
   def display_output(output) do
     IO.puts(output)
     :ok

--- a/lib/cogctl/actions/bundles.ex
+++ b/lib/cogctl/actions/bundles.ex
@@ -6,14 +6,8 @@ defmodule Cogctl.Actions.Bundles do
     []
   end
 
-  def run(_options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_list(client)
-      {:error, error} ->
-        display_error(error["error"])
-    end
-  end
+  def run(_options, _args, _config, client),
+    do: with_authentication(client, &do_list/1)
 
   defp do_list(client) do
     case CogApi.bundle_index(client) do

--- a/lib/cogctl/actions/bundles/delete.ex
+++ b/lib/cogctl/actions/bundles/delete.ex
@@ -5,14 +5,8 @@ defmodule Cogctl.Actions.Bundles.Delete do
     []
   end
 
-  def run(_options, args,  _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_delete(client, args)
-      {:error, error} ->
-        display_error(error["error"])
-    end
-  end
+  def run(_options, args,  _config, client),
+    do: with_authentication(client, &do_delete(&1, args))
 
   defp do_delete(_client, []) do
     display_arguments_error

--- a/lib/cogctl/actions/bundles/disable.ex
+++ b/lib/cogctl/actions/bundles/disable.ex
@@ -6,12 +6,8 @@ defmodule Cogctl.Actions.Bundles.Disable do
   end
 
   def run(options, _args,  _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_disable(client, :proplists.get_value(:bundle, options))
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    with_authentication(client,
+                        &do_disable(&1, :proplists.get_value(:bundle, options)))
   end
 
   defp do_disable(client, bundle_name) do

--- a/lib/cogctl/actions/bundles/enable.ex
+++ b/lib/cogctl/actions/bundles/enable.ex
@@ -6,12 +6,8 @@ defmodule Cogctl.Actions.Bundles.Enable do
   end
 
   def run(options, _args,  _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_enable(client, :proplists.get_value(:bundle, options))
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    with_authentication(client,
+                        &do_enable(&1, :proplists.get_value(:bundle, options)))
   end
 
   defp do_enable(client, bundle_name) do

--- a/lib/cogctl/actions/bundles/info.ex
+++ b/lib/cogctl/actions/bundles/info.ex
@@ -8,12 +8,8 @@ defmodule Cogctl.Actions.Bundles.Info do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_info(client, :proplists.get_value(:bundle, options))
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    with_authentication(client,
+                        &do_info(&1, :proplists.get_value(:bundle, options)))
   end
 
   defp do_info(_client, :undefined) do

--- a/lib/cogctl/actions/chat_handles.ex
+++ b/lib/cogctl/actions/chat_handles.ex
@@ -6,14 +6,8 @@ defmodule Cogctl.Actions.ChatHandles do
     []
   end
 
-  def run(_options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_list(client)
-      {:error, error} ->
-        display_error(error["error"])
-    end
-  end
+  def run(_options, _args, _config, client),
+    do: with_authentication(client, &do_list/1)
 
   defp do_list(client) do
     case CogApi.chat_handle_index(client) do

--- a/lib/cogctl/actions/chat_handles/create.ex
+++ b/lib/cogctl/actions/chat_handles/create.ex
@@ -9,13 +9,8 @@ defmodule Cogctl.Actions.ChatHandles.Create do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        params = convert_to_params(options, [user: :required, chat_provider: :required, handle: :required])
-        do_create(client, params)
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    params = convert_to_params(options, [user: :required, chat_provider: :required, handle: :required])
+    with_authentication(client, &do_create(&1, params))
   end
 
   defp do_create(_client, :error) do

--- a/lib/cogctl/actions/chat_handles/delete.ex
+++ b/lib/cogctl/actions/chat_handles/delete.ex
@@ -7,13 +7,8 @@ defmodule Cogctl.Actions.ChatHandles.Delete do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        params = convert_to_params(options, [user: :required, chat_provider: :required])
-        do_delete(client, params)
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    params = convert_to_params(options, [user: :required, chat_provider: :required])
+    with_authentication(client, &do_delete(&1, params))
   end
 
   defp do_delete(_client, :error) do

--- a/lib/cogctl/actions/groups.ex
+++ b/lib/cogctl/actions/groups.ex
@@ -6,14 +6,8 @@ defmodule Cogctl.Actions.Groups do
     []
   end
 
-  def run(_options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_list(client)
-      {:error, error} ->
-        display_error(error["error"])
-    end
-  end
+  def run(_options, _args, _config, client),
+    do: with_authentication(client, &do_list/1)
 
   defp do_list(client) do
     case CogApi.group_index(client) do

--- a/lib/cogctl/actions/groups/add.ex
+++ b/lib/cogctl/actions/groups/add.ex
@@ -9,15 +9,12 @@ defmodule Cogctl.Actions.Groups.Add do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        group = :proplists.get_value(:group, options)
-        user_to_add = :proplists.get_value(:user_to_add, options)
-        group_to_add = :proplists.get_value(:group_to_add, options)
-        do_add(client, group, user_to_add, group_to_add)
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    group = :proplists.get_value(:group, options)
+    user_to_add = :proplists.get_value(:user_to_add, options)
+    group_to_add = :proplists.get_value(:group_to_add, options)
+
+    with_authentication(client,
+                        &do_add(&1, group, user_to_add, group_to_add))
   end
 
   defp do_add(_client, :undefined, _user_to_add, _group_to_add) do

--- a/lib/cogctl/actions/groups/create.ex
+++ b/lib/cogctl/actions/groups/create.ex
@@ -7,12 +7,8 @@ defmodule Cogctl.Actions.Groups.Create do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_create(client, :proplists.get_value(:name, options))
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    with_authentication(client,
+                        &do_create(&1, :proplists.get_value(:name, options)))
   end
 
   defp do_create(_client, :undefined) do

--- a/lib/cogctl/actions/groups/delete.ex
+++ b/lib/cogctl/actions/groups/delete.ex
@@ -6,12 +6,8 @@ defmodule Cogctl.Actions.Groups.Delete do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_delete(client, :proplists.get_value(:group, options))
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    with_authentication(client,
+                        &do_delete(&1, :proplists.get_value(:group, options)))
   end
 
   defp do_delete(_client, :undefined) do

--- a/lib/cogctl/actions/groups/info.ex
+++ b/lib/cogctl/actions/groups/info.ex
@@ -8,12 +8,8 @@ defmodule Cogctl.Actions.Groups.Info do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_info(client, :proplists.get_value(:group, options))
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    with_authentication(client,
+                        &do_info(&1, :proplists.get_value(:group, options)))
   end
 
   defp do_info(_client, :undefined) do

--- a/lib/cogctl/actions/groups/remove.ex
+++ b/lib/cogctl/actions/groups/remove.ex
@@ -9,15 +9,12 @@ defmodule Cogctl.Actions.Groups.Remove do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        group = :proplists.get_value(:group, options)
-        user_to_remove = :proplists.get_value(:user_to_remove, options)
-        group_to_remove = :proplists.get_value(:group_to_remove, options)
-        do_remove(client, group, user_to_remove, group_to_remove)
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    group = :proplists.get_value(:group, options)
+    user_to_remove = :proplists.get_value(:user_to_remove, options)
+    group_to_remove = :proplists.get_value(:group_to_remove, options)
+
+    with_authentication(client,
+                        &do_remove(&1, group, user_to_remove, group_to_remove))
   end
 
   defp do_remove(_client, :undefined, _user_to_add, _group_to_add) do

--- a/lib/cogctl/actions/groups/update.ex
+++ b/lib/cogctl/actions/groups/update.ex
@@ -8,13 +8,9 @@ defmodule Cogctl.Actions.Groups.Update do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        params = convert_to_params(options, [name: :optional])
-        do_update(client, :proplists.get_value(:group, options), params)
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    params = convert_to_params(options, [name: :optional])
+    with_authentication(client,
+                        &do_update(&1, :proplists.get_value(:group, options), params))
   end
 
   defp do_update(_client, :undefined, _options) do

--- a/lib/cogctl/actions/permissions.ex
+++ b/lib/cogctl/actions/permissions.ex
@@ -9,13 +9,9 @@ defmodule Cogctl.Actions.Permissions do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        params = convert_to_params(options, [user: :optional, group: :optional, role: :optional])
-        do_list(client, params)
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    params = convert_to_params(options, [user: :optional, group: :optional, role: :optional])
+    with_authentication(client,
+                        &do_list(&1, params))
   end
 
   defp do_list(_client, :error) do

--- a/lib/cogctl/actions/permissions/create.ex
+++ b/lib/cogctl/actions/permissions/create.ex
@@ -6,12 +6,8 @@ defmodule Cogctl.Actions.Permissions.Create do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_create(client, :proplists.get_value(:name, options))
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    with_authentication(client,
+                        &do_create(&1, :proplists.get_value(:name, options)))
   end
 
   defp do_create(_client, :undefined) do

--- a/lib/cogctl/actions/permissions/delete.ex
+++ b/lib/cogctl/actions/permissions/delete.ex
@@ -6,12 +6,8 @@ defmodule Cogctl.Actions.Permissions.Delete do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_delete(client, :proplists.get_value(:permission, options))
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    with_authentication(client,
+                        &do_delete(&1, :proplists.get_value(:permission, options)))
   end
 
   defp do_delete(_client, :undefined) do

--- a/lib/cogctl/actions/permissions/grant.ex
+++ b/lib/cogctl/actions/permissions/grant.ex
@@ -9,16 +9,13 @@ defmodule Cogctl.Actions.Permissions.Grant do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        permission = :proplists.get_value(:permission, options)
-        user_to_grant = :proplists.get_value(:user_to_grant, options)
-        group_to_grant = :proplists.get_value(:group_to_grant, options)
-        role_to_grant = :proplists.get_value(:role_to_grant, options)
-        do_grant(client, permission, user_to_grant, group_to_grant, role_to_grant)
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    permission = :proplists.get_value(:permission, options)
+    user_to_grant = :proplists.get_value(:user_to_grant, options)
+    group_to_grant = :proplists.get_value(:group_to_grant, options)
+    role_to_grant = :proplists.get_value(:role_to_grant, options)
+
+    with_authentication(client,
+                        &do_grant(&1, permission, user_to_grant, group_to_grant, role_to_grant))
   end
 
   defp do_grant(_client, :undefined, _user_to_grant, _group_to_grant, _role_to_grant) do

--- a/lib/cogctl/actions/permissions/revoke.ex
+++ b/lib/cogctl/actions/permissions/revoke.ex
@@ -9,16 +9,13 @@ defmodule Cogctl.Actions.Permissions.Revoke do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        permission = :proplists.get_value(:permission, options)
-        user_to_revoke = :proplists.get_value(:user_to_revoke, options)
-        group_to_revoke = :proplists.get_value(:group_to_revoke, options)
-        role_to_revoke = :proplists.get_value(:role_to_revoke, options)
-        do_revoke(client, permission, user_to_revoke, group_to_revoke, role_to_revoke)
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    permission = :proplists.get_value(:permission, options)
+    user_to_revoke = :proplists.get_value(:user_to_revoke, options)
+    group_to_revoke = :proplists.get_value(:group_to_revoke, options)
+    role_to_revoke = :proplists.get_value(:role_to_revoke, options)
+
+    with_authentication(client,
+                        &do_revoke(&1, permission, user_to_revoke, group_to_revoke, role_to_revoke))
   end
 
   defp do_revoke(_client, :undefined, _user_to_revoke, _group_to_revoke, _role_to_revoke) do

--- a/lib/cogctl/actions/roles.ex
+++ b/lib/cogctl/actions/roles.ex
@@ -6,14 +6,8 @@ defmodule Cogctl.Actions.Roles do
     []
   end
 
-  def run(_options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_list(client)
-      {:error, error} ->
-        display_error(error["error"])
-    end
-  end
+  def run(_options, _args, _config, client),
+    do: with_authentication(client, &do_list/1)
 
   defp do_list(client) do
     case CogApi.role_index(client) do

--- a/lib/cogctl/actions/roles/create.ex
+++ b/lib/cogctl/actions/roles/create.ex
@@ -7,12 +7,8 @@ defmodule Cogctl.Actions.Roles.Create do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_create(client, :proplists.get_value(:name, options))
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    with_authentication(client,
+                        &do_create(&1, :proplists.get_value(:name, options)))
   end
 
   defp do_create(_client, :undefined) do

--- a/lib/cogctl/actions/roles/delete.ex
+++ b/lib/cogctl/actions/roles/delete.ex
@@ -6,12 +6,8 @@ defmodule Cogctl.Actions.Roles.Delete do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_delete(client, :proplists.get_value(:role, options))
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    with_authentication(client,
+                        &do_delete(&1, :proplists.get_value(:role, options)))
   end
 
   defp do_delete(_client, :undefined) do

--- a/lib/cogctl/actions/roles/grant.ex
+++ b/lib/cogctl/actions/roles/grant.ex
@@ -8,15 +8,12 @@ defmodule Cogctl.Actions.Roles.Grant do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        role = :proplists.get_value(:role, options)
-        user_to_grant = :proplists.get_value(:user_to_grant, options)
-        group_to_grant = :proplists.get_value(:group_to_grant, options)
-        do_grant(client, role, user_to_grant, group_to_grant)
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    role = :proplists.get_value(:role, options)
+    user_to_grant = :proplists.get_value(:user_to_grant, options)
+    group_to_grant = :proplists.get_value(:group_to_grant, options)
+
+    with_authentication(client,
+                        &do_grant(&1, role, user_to_grant, group_to_grant))
   end
 
   defp do_grant(_client, :undefined, _user_to_grant, _group_to_grant) do

--- a/lib/cogctl/actions/roles/revoke.ex
+++ b/lib/cogctl/actions/roles/revoke.ex
@@ -8,15 +8,12 @@ defmodule Cogctl.Actions.Roles.Revoke do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        role = :proplists.get_value(:role, options)
-        user_to_revoke = :proplists.get_value(:user_to_revoke, options)
-        group_to_revoke = :proplists.get_value(:group_to_revoke, options)
-        do_revoke(client, role, user_to_revoke, group_to_revoke)
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    role = :proplists.get_value(:role, options)
+    user_to_revoke = :proplists.get_value(:user_to_revoke, options)
+    group_to_revoke = :proplists.get_value(:group_to_revoke, options)
+
+    with_authentication(client,
+                        &do_revoke(&1, role, user_to_revoke, group_to_revoke))
   end
 
   defp do_revoke(_client, :undefined, _user_to_revoke, _group_to_revoke) do

--- a/lib/cogctl/actions/roles/update.ex
+++ b/lib/cogctl/actions/roles/update.ex
@@ -8,13 +8,9 @@ defmodule Cogctl.Actions.Roles.Update do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        params = convert_to_params(options, [name: :optional])
-        do_update(client, :proplists.get_value(:role, options), params)
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    params = convert_to_params(options, [name: :optional])
+    with_authentication(client,
+                        &do_update(&1, :proplists.get_value(:role, options), params))
   end
 
   defp do_update(_client, :undefined, _params) do

--- a/lib/cogctl/actions/rules.ex
+++ b/lib/cogctl/actions/rules.ex
@@ -7,12 +7,8 @@ defmodule Cogctl.Actions.Rules do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_list(client, :proplists.get_value(:command, options))
-      {:error, error} ->
-        display_error(error["errors"])
-    end
+    with_authentication(client,
+                        &do_list(&1, :proplists.get_value(:command, options)))
   end
 
   defp do_list(_client, :undefined) do

--- a/lib/cogctl/actions/rules/create.ex
+++ b/lib/cogctl/actions/rules/create.ex
@@ -7,12 +7,8 @@ defmodule Cogctl.Actions.Rules.Create do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_create(client, :proplists.get_value(:rule_text, options))
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    with_authentication(client,
+                        &do_create(&1, :proplists.get_value(:rule_text, options)))
   end
 
   defp do_create(_client, :undefined) do

--- a/lib/cogctl/actions/rules/delete.ex
+++ b/lib/cogctl/actions/rules/delete.ex
@@ -6,12 +6,8 @@ defmodule Cogctl.Actions.Rules.Delete do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_delete(client, :proplists.get_value(:rule, options))
-      {:error, error} ->
-        display_error(error["errors"])
-    end
+    with_authentication(client,
+                        &do_delete(&1, :proplists.get_value(:rule, options)))
   end
 
   defp do_delete(_client, :undefined) do

--- a/lib/cogctl/actions/users.ex
+++ b/lib/cogctl/actions/users.ex
@@ -6,14 +6,8 @@ defmodule Cogctl.Actions.Users do
     []
   end
 
-  def run(_options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_list(client)
-      {:error, error} ->
-        display_error(error["error"])
-    end
-  end
+  def run(_options, _args, _config, client),
+    do: with_authentication(client, &do_list/1)
 
   defp do_list(client) do
     case CogApi.user_index(client) do

--- a/lib/cogctl/actions/users/create.ex
+++ b/lib/cogctl/actions/users/create.ex
@@ -14,17 +14,13 @@ defmodule Cogctl.Actions.Users.Create do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        params = convert_to_params(options, [first_name: :required,
-                                             last_name: :required,
-                                             email_address: :required,
-                                             username: :required,
-                                             password: :required])
-        do_create(client, params)
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    params = convert_to_params(options, [first_name: :required,
+                                         last_name: :required,
+                                         email_address: :required,
+                                         username: :required,
+                                         password: :required])
+
+    with_authentication(client, &do_create(&1, params))
   end
 
   defp do_create(_client, :error) do

--- a/lib/cogctl/actions/users/delete.ex
+++ b/lib/cogctl/actions/users/delete.ex
@@ -6,12 +6,8 @@ defmodule Cogctl.Actions.Users.Delete do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_delete(client, :proplists.get_value(:user, options))
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    with_authentication(client,
+                        &do_delete(&1, :proplists.get_value(:user, options)))
   end
 
   defp do_delete(_client, :undefined) do

--- a/lib/cogctl/actions/users/info.ex
+++ b/lib/cogctl/actions/users/info.ex
@@ -7,12 +7,8 @@ defmodule Cogctl.Actions.Users.Info do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        do_info(client, :proplists.get_value(:user, options))
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    with_authentication(client,
+                        &do_info(&1, :proplists.get_value(:user, options)))
   end
 
   defp do_info(_client, :undefined) do

--- a/lib/cogctl/actions/users/update.ex
+++ b/lib/cogctl/actions/users/update.ex
@@ -12,17 +12,14 @@ defmodule Cogctl.Actions.Users.Update do
   end
 
   def run(options, _args, _config, client) do
-    case CogApi.authenticate(client) do
-      {:ok, client} ->
-        params = convert_to_params(options, [first_name: :optional,
-                                             last_name: :optional,
-                                             email_address: :optional,
-                                             username: :optional,
-                                             password: :optional])
-        do_update(client, :proplists.get_value(:user, options), params)
-      {:error, error} ->
-        display_error(error["error"])
-    end
+    params = convert_to_params(options, [first_name: :optional,
+                                         last_name: :optional,
+                                         email_address: :optional,
+                                         username: :optional,
+                                         password: :optional])
+
+    with_authentication(client,
+                        &do_update(&1, :proplists.get_value(:user, options), params))
   end
 
   defp do_update(_client, _user_username, :error) do

--- a/test/cogctl/action_util_test.exs
+++ b/test/cogctl/action_util_test.exs
@@ -12,4 +12,39 @@ defmodule Cogctl.ActionUtilTest do
     params = ActionUtil.convert_to_params([a: true, b: :undefined, c: false], [b: :required, c: :optional])
     assert params == :error
   end
+
+  test "with_authentication runs function when authentication succeeds" do
+    defmodule AuthEveryone do
+      def authenticate(client),
+        do: {:ok, client}
+    end
+    me = self()
+    result = ActionUtil.with_authentication(:my_client,
+      fn(:my_client) ->
+        send(me, :function_ran)
+        :success
+      end,
+      AuthEveryone)
+
+    assert result == :success
+    assert_receive :function_ran
+  end
+
+  test "with_authentication returns error without running callback when authentication fails" do
+    defmodule RejectEveryone do
+      def authenticate(_client),
+        do: {:error, %{"error" => "nope"}}
+    end
+
+    me = self()
+    result = ActionUtil.with_authentication(:my_client,
+      fn(:my_client) ->
+        send(me, :function_ran)
+      end,
+      RejectEveryone)
+
+    assert result == :error
+    refute_receive :function_ran
+  end
+
 end


### PR DESCRIPTION
Add a `with_authentication` wrapper that executes a function after
ensuring that an API token is available. If an authentication error
occurs, a helpful message is printed to standard error, informing the
user how to proceed.

All existing calls to `CogApi.authenticate/1` were converted to use this
wrapper, and tests for the wrapper logic are in place.

Fixes https://github.com/operable/cog/issues/371