### PR TITLE
Update cogctl to use the CogApi old version

### DIFF
--- a/lib/cogctl.ex
+++ b/lib/cogctl.ex
@@ -44,13 +44,13 @@ defmodule Cogctl do
                 profile -> profile
               end
     profile = apply_overrides(profile, options)
-    client = new_client(profile)
+    endpoint = new_endpoint(profile)
 
-    {:ok, client}
+    {:ok, endpoint}
   end
 
-  defp new_client(profile=%Cogctl.Profile{}) do
-    %CogApi{
+  defp new_endpoint(profile=%Cogctl.Profile{}) do
+    %CogApi.Endpoint{
       proto: protocol(profile),
       host: profile.host,
       port: profile.port,

--- a/lib/cogctl/action.ex
+++ b/lib/cogctl/action.ex
@@ -7,7 +7,7 @@ defmodule Cogctl.Action do
 
   @callback option_spec() :: [:optparse.option_spec()]
 
-  @callback run(parsed_options(), remaining_args(), %Cogctl.Config{}, %Cogctl.Profile{}) :: :ok | {:error, term()} | :error
+  @callback run(parsed_options(), remaining_args(), %Cogctl.Config{}, %Cogctl.Profile{}) :: :ok | {:errors, term()} | :error
 
   defmacro __using__(name) when name != nil do
     pattern = String.split(name, " ")

--- a/lib/cogctl/action_util.ex
+++ b/lib/cogctl/action_util.ex
@@ -29,7 +29,7 @@ defmodule Cogctl.ActionUtil do
 
   @doc """
   Wraps an operation with a call to authenticate against the Cog
-  API. The resulting client (ensured to have a token) will be passed
+  API. The resulting endpoint (ensured to have a token) will be passed
   to an arity-1 function that will perform the desired action.
 
   Any authentication-related error is handled for you; errors that
@@ -41,11 +41,11 @@ defmodule Cogctl.ActionUtil do
   implementations for testing purposes, and generally isn't useful
   outside of that context.
   """
-  @spec with_authentication(%Cogctl.Profile{}, (%Cogctl.Profile{} -> term), module) :: term
-  def with_authentication(client, fun, api \\ CogApi) do
-    case api.authenticate(client) do
-      {:ok, client_with_token} ->
-        fun.(client_with_token)
+  @spec with_authentication(%CogApi.Endpoint{}, (%CogApi.Endpoint{} -> term), module) :: term
+  def with_authentication(endpoint, fun, api \\ CogApi.HTTP.Client) do
+    case api.authenticate(endpoint) do
+      {:ok, endpoint_with_token} ->
+        fun.(endpoint_with_token)
       {:error, error} ->
         IO.puts(:stderr, """
         #{error["error"]}
@@ -64,7 +64,7 @@ defmodule Cogctl.ActionUtil do
   end
 
   def display_error(error) do
-    IO.puts(:stderr, "ERROR: #{error}")
+    IO.puts(:stderr, "ERROR: #{inspect error}")
     :error
   end
 

--- a/lib/cogctl/actions/bundles.ex
+++ b/lib/cogctl/actions/bundles.ex
@@ -6,11 +6,11 @@ defmodule Cogctl.Actions.Bundles do
     []
   end
 
-  def run(_options, _args, _config, client),
-    do: with_authentication(client, &do_list/1)
+  def run(_options, _args, _config, endpoint),
+    do: with_authentication(endpoint, &do_list/1)
 
-  defp do_list(client) do
-    case CogApi.bundle_index(client) do
+  defp do_list(endpoint) do
+    case CogApi.HTTP.Old.bundle_index(endpoint) do
       {:ok, resp} ->
         bundles = for bundle <- resp["bundles"] do
           [bundle["name"], enabled_to_status(bundle["enabled"]), bundle["inserted_at"]]
@@ -18,7 +18,7 @@ defmodule Cogctl.Actions.Bundles do
 
         display_output(Table.format([["NAME", "STATUS", "INSTALLED"]] ++ bundles, true))
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 

--- a/lib/cogctl/actions/bundles/delete.ex
+++ b/lib/cogctl/actions/bundles/delete.ex
@@ -5,16 +5,16 @@ defmodule Cogctl.Actions.Bundles.Delete do
     []
   end
 
-  def run(_options, args,  _config, client),
-    do: with_authentication(client, &do_delete(&1, args))
+  def run(_options, args,  _config, endpoint),
+    do: with_authentication(endpoint, &do_delete(&1, args))
 
-  defp do_delete(_client, []) do
+  defp do_delete(_endpoint, []) do
     display_arguments_error
   end
 
-  defp do_delete(client, bundle_names) when is_list(bundle_names) do
+  defp do_delete(endpoint, bundle_names) when is_list(bundle_names) do
     Enum.reduce_while(bundle_names, :ok, fn bundle_name, _acc ->
-      case do_delete(client, bundle_name) do
+      case do_delete(endpoint, bundle_name) do
         :ok ->
           {:cont, :ok}
         :error ->
@@ -23,12 +23,12 @@ defmodule Cogctl.Actions.Bundles.Delete do
     end)
   end
 
-  defp do_delete(client, bundle_name) do
-    case CogApi.bundle_delete(client, bundle_name) do
+  defp do_delete(endpoint, bundle_name) do
+    case CogApi.HTTP.Old.bundle_delete(endpoint, bundle_name) do
       :ok ->
         display_output("Deleted #{bundle_name}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/bundles/disable.ex
+++ b/lib/cogctl/actions/bundles/disable.ex
@@ -5,17 +5,17 @@ defmodule Cogctl.Actions.Bundles.Disable do
     [{:bundle, :undefined, :undefined, {:string, :undefined}, 'Bundle name'}]
   end
 
-  def run(options, _args,  _config, client) do
-    with_authentication(client,
+  def run(options, _args,  _config, endpoint) do
+    with_authentication(endpoint,
                         &do_disable(&1, :proplists.get_value(:bundle, options)))
   end
 
-  defp do_disable(client, bundle_name) do
-    case CogApi.bundle_disable(client, bundle_name) do
+  defp do_disable(endpoint, bundle_name) do
+    case CogApi.HTTP.Old.bundle_disable(endpoint, bundle_name) do
       {:ok, _} ->
         display_output("Disabled #{bundle_name}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/bundles/enable.ex
+++ b/lib/cogctl/actions/bundles/enable.ex
@@ -5,17 +5,17 @@ defmodule Cogctl.Actions.Bundles.Enable do
     [{:bundle, :undefined, :undefined, {:string, :undefined}, 'Bundle name (required)'}]
   end
 
-  def run(options, _args,  _config, client) do
-    with_authentication(client,
+  def run(options, _args,  _config, endpoint) do
+    with_authentication(endpoint,
                         &do_enable(&1, :proplists.get_value(:bundle, options)))
   end
 
-  defp do_enable(client, bundle_name) do
-    case CogApi.bundle_enable(client, bundle_name) do
+  defp do_enable(endpoint, bundle_name) do
+    case CogApi.HTTP.Old.bundle_enable(endpoint, bundle_name) do
       {:ok, _} ->
         display_output("Enabled #{bundle_name}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/bundles/info.ex
+++ b/lib/cogctl/actions/bundles/info.ex
@@ -7,17 +7,17 @@ defmodule Cogctl.Actions.Bundles.Info do
     [{:bundle, :undefined, :undefined, {:string, :undefined}, 'Bundle name (required)'}]
   end
 
-  def run(options, _args, _config, client) do
-    with_authentication(client,
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
                         &do_info(&1, :proplists.get_value(:bundle, options)))
   end
 
-  defp do_info(_client, :undefined) do
+  defp do_info(_endpoint, :undefined) do
     display_error("Missing required arguments")
   end
 
-  defp do_info(client, bundle_name) do
-    case CogApi.bundle_show(client, bundle_name) do
+  defp do_info(endpoint, bundle_name) do
+    case CogApi.HTTP.Old.bundle_show(endpoint, bundle_name) do
       {:ok, resp} ->
         bundle = resp["bundle"]
 
@@ -39,7 +39,7 @@ defmodule Cogctl.Actions.Bundles.Info do
         #{Table.format([["NAME", "ID"]|commands], true)}
         """ |> String.rstrip)
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/chat_handles.ex
+++ b/lib/cogctl/actions/chat_handles.ex
@@ -6,11 +6,11 @@ defmodule Cogctl.Actions.ChatHandles do
     []
   end
 
-  def run(_options, _args, _config, client),
-    do: with_authentication(client, &do_list/1)
+  def run(_options, _args, _config, endpoint),
+    do: with_authentication(endpoint, &do_list/1)
 
-  defp do_list(client) do
-    case CogApi.chat_handle_index(client) do
+  defp do_list(endpoint) do
+    case CogApi.HTTP.Old.chat_handle_index(endpoint) do
       {:ok, resp} ->
         chat_handles = resp["chat_handles"]
         chat_handle_attrs = for chat_handle <- chat_handles do
@@ -19,7 +19,7 @@ defmodule Cogctl.Actions.ChatHandles do
 
         display_output(Table.format([["USER", "CHAT PROVIDER", "HANDLE"]] ++ chat_handle_attrs, true))
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/chat_handles/create.ex
+++ b/lib/cogctl/actions/chat_handles/create.ex
@@ -8,17 +8,17 @@ defmodule Cogctl.Actions.ChatHandles.Create do
      {:handle, :undefined, 'handle', {:string, :undefined}, 'Handle (required)'}]
   end
 
-  def run(options, _args, _config, client) do
+  def run(options, _args, _config, endpoint) do
     params = convert_to_params(options, [user: :required, chat_provider: :required, handle: :required])
-    with_authentication(client, &do_create(&1, params))
+    with_authentication(endpoint, &do_create(&1, params))
   end
 
-  defp do_create(_client, :error) do
+  defp do_create(_endpoint, :error) do
     display_arguments_error
   end
 
-  defp do_create(client, {:ok, params}) do
-    case CogApi.chat_handle_create(client, %{chat_handle: params}) do
+  defp do_create(endpoint, {:ok, params}) do
+    case CogApi.HTTP.Old.chat_handle_create(endpoint, %{chat_handle: params}) do
       {:ok, resp} ->
         chat_handle = resp["chat_handle"]
         user = chat_handle["user"]["username"]
@@ -36,7 +36,7 @@ defmodule Cogctl.Actions.ChatHandles.Create do
         #{Table.format(chat_handle_attrs, false)}
         """ |> String.rstrip)
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/chat_handles/delete.ex
+++ b/lib/cogctl/actions/chat_handles/delete.ex
@@ -6,21 +6,21 @@ defmodule Cogctl.Actions.ChatHandles.Delete do
      {:chat_provider, :undefined, 'chat-provider', {:string, :undefined}, 'Chat provider name (required)'}]
   end
 
-  def run(options, _args, _config, client) do
+  def run(options, _args, _config, endpoint) do
     params = convert_to_params(options, [user: :required, chat_provider: :required])
-    with_authentication(client, &do_delete(&1, params))
+    with_authentication(endpoint, &do_delete(&1, params))
   end
 
-  defp do_delete(_client, :error) do
+  defp do_delete(_endpoint, :error) do
     display_arguments_error
   end
 
-  defp do_delete(client, {:ok, params}) do
-    case CogApi.chat_handle_delete(client, %{chat_handle: params}) do
+  defp do_delete(endpoint, {:ok, params}) do
+    case CogApi.HTTP.Old.chat_handle_delete(endpoint, %{chat_handle: params}) do
       :ok ->
         display_output("Deleted chat handle owned by #{params[:user]} for #{params[:chat_provider]} chat provider")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/groups.ex
+++ b/lib/cogctl/actions/groups.ex
@@ -6,11 +6,11 @@ defmodule Cogctl.Actions.Groups do
     []
   end
 
-  def run(_options, _args, _config, client),
-    do: with_authentication(client, &do_list/1)
+  def run(_options, _args, _config, endpoint),
+    do: with_authentication(endpoint, &do_list/1)
 
-  defp do_list(client) do
-    case CogApi.group_index(client) do
+  defp do_list(endpoint) do
+    case CogApi.HTTP.Old.group_index(endpoint) do
       {:ok, resp} ->
         groups = resp["groups"]
         group_attrs = for group <- groups do
@@ -19,7 +19,7 @@ defmodule Cogctl.Actions.Groups do
 
         display_output(Table.format([["NAME", "ID"]] ++ group_attrs, true))
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 

--- a/lib/cogctl/actions/groups/add.ex
+++ b/lib/cogctl/actions/groups/add.ex
@@ -8,25 +8,25 @@ defmodule Cogctl.Actions.Groups.Add do
      {:group_to_add, :undefined, 'group', {:string, :undefined}, 'Name of group to add'}]
   end
 
-  def run(options, _args, _config, client) do
+  def run(options, _args, _config, endpoint) do
     group = :proplists.get_value(:group, options)
     user_to_add = :proplists.get_value(:user_to_add, options)
     group_to_add = :proplists.get_value(:group_to_add, options)
 
-    with_authentication(client,
+    with_authentication(endpoint,
                         &do_add(&1, group, user_to_add, group_to_add))
   end
 
-  defp do_add(_client, :undefined, _user_to_add, _group_to_add) do
+  defp do_add(_endpoint, :undefined, _user_to_add, _group_to_add) do
     display_arguments_error
   end
 
-  defp do_add(_client, _group_name, :undefined, :undefined) do
+  defp do_add(_endpoint, _group_name, :undefined, :undefined) do
     display_arguments_error
   end
 
-  defp do_add(client, group_name, user_to_add, :undefined) do
-    case CogApi.group_add(client, group_name, :users, user_to_add) do
+  defp do_add(endpoint, group_name, user_to_add, :undefined) do
+    case CogApi.HTTP.Old.group_add(endpoint, group_name, :users, user_to_add) do
       {:ok, resp} ->
         group = resp["group"]
 
@@ -36,12 +36,12 @@ defmodule Cogctl.Actions.Groups.Add do
         #{Groups.render_memberships(group)}
         """ |> String.rstrip)
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_add(client, group_name, :undefined, group_to_add) do
-    case CogApi.group_add(client, group_name, :groups, group_to_add) do
+  defp do_add(endpoint, group_name, :undefined, group_to_add) do
+    case CogApi.HTTP.Old.group_add(endpoint, group_name, :groups, group_to_add) do
       {:ok, resp} ->
         group = resp["group"]
 
@@ -51,11 +51,11 @@ defmodule Cogctl.Actions.Groups.Add do
         #{Groups.render_memberships(group)}
         """ |> String.rstrip)
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_add(_client, _group_name, _user_to_add, _group_to_add) do
+  defp do_add(_endpoint, _group_name, _user_to_add, _group_to_add) do
     display_arguments_error
   end
 end

--- a/lib/cogctl/actions/groups/create.ex
+++ b/lib/cogctl/actions/groups/create.ex
@@ -6,17 +6,17 @@ defmodule Cogctl.Actions.Groups.Create do
     [{:name, :undefined, 'name', {:string, :undefined}, 'Group name (required)'}]
   end
 
-  def run(options, _args, _config, client) do
-    with_authentication(client,
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
                         &do_create(&1, :proplists.get_value(:name, options)))
   end
 
-  defp do_create(_client, :undefined) do
+  defp do_create(_endpoint, :undefined) do
     display_arguments_error
   end
 
-  defp do_create(client, name) do
-    case CogApi.group_create(client, %{group: %{name: name}}) do
+  defp do_create(endpoint, name) do
+    case CogApi.HTTP.Old.group_create(endpoint, %{group: %{name: name}}) do
       {:ok, resp} ->
         group = resp["group"]
         name = group["name"]
@@ -31,7 +31,7 @@ defmodule Cogctl.Actions.Groups.Create do
         #{Table.format(group_attrs, false)}
         """ |> String.rstrip)
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/groups/delete.ex
+++ b/lib/cogctl/actions/groups/delete.ex
@@ -5,21 +5,21 @@ defmodule Cogctl.Actions.Groups.Delete do
     [{:group, :undefined, :undefined, {:string, :undefined}, 'Group name (required)'}]
   end
 
-  def run(options, _args, _config, client) do
-    with_authentication(client,
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
                         &do_delete(&1, :proplists.get_value(:group, options)))
   end
 
-  defp do_delete(_client, :undefined) do
+  defp do_delete(_endpoint, :undefined) do
     display_arguments_error
   end
 
-  defp do_delete(client, group_name) do
-    case CogApi.group_delete(client, group_name) do
+  defp do_delete(endpoint, group_name) do
+    case CogApi.HTTP.Old.group_delete(endpoint, group_name) do
       :ok ->
         display_output("Deleted #{group_name}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/groups/info.ex
+++ b/lib/cogctl/actions/groups/info.ex
@@ -7,17 +7,17 @@ defmodule Cogctl.Actions.Groups.Info do
     [{:group, :undefined, :undefined, {:string, :undefined}, 'Group name (required)'}]
   end
 
-  def run(options, _args, _config, client) do
-    with_authentication(client,
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
                         &do_info(&1, :proplists.get_value(:group, options)))
   end
 
-  defp do_info(_client, :undefined) do
+  defp do_info(_endpoint, :undefined) do
     display_arguments_error
   end
 
-  defp do_info(client, group_name) do
-    case CogApi.group_show(client, group_name) do
+  defp do_info(endpoint, group_name) do
+    case CogApi.HTTP.Old.group_show(endpoint, group_name) do
       {:ok, resp} ->
         group = resp["group"]
 
@@ -31,7 +31,7 @@ defmodule Cogctl.Actions.Groups.Info do
         #{Groups.render_memberships(group)}
         """ |> String.rstrip)
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/groups/remove.ex
+++ b/lib/cogctl/actions/groups/remove.ex
@@ -8,25 +8,25 @@ defmodule Cogctl.Actions.Groups.Remove do
      {:group_to_remove, :undefined, 'group', {:string, :undefined}, 'Name of group to remove'}]
   end
 
-  def run(options, _args, _config, client) do
+  def run(options, _args, _config, endpoint) do
     group = :proplists.get_value(:group, options)
     user_to_remove = :proplists.get_value(:user_to_remove, options)
     group_to_remove = :proplists.get_value(:group_to_remove, options)
 
-    with_authentication(client,
+    with_authentication(endpoint,
                         &do_remove(&1, group, user_to_remove, group_to_remove))
   end
 
-  defp do_remove(_client, :undefined, _user_to_add, _group_to_add) do
+  defp do_remove(_endpoint, :undefined, _user_to_add, _group_to_add) do
     display_arguments_error
   end
 
-  defp do_remove(_client, _group_name, :undefined, :undefined) do
+  defp do_remove(_endpoint, _group_name, :undefined, :undefined) do
     display_arguments_error
   end
 
-  defp do_remove(client, group_name, user_to_remove, :undefined) do
-    case CogApi.group_remove(client, group_name, :users, user_to_remove) do
+  defp do_remove(endpoint, group_name, user_to_remove, :undefined) do
+    case CogApi.HTTP.Old.group_remove(endpoint, group_name, :users, user_to_remove) do
       {:ok, resp} ->
         group = resp["group"]
 
@@ -36,12 +36,12 @@ defmodule Cogctl.Actions.Groups.Remove do
         #{Groups.render_memberships(group)}
         """ |> String.rstrip)
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_remove(client, group_name, :undefined, group_to_remove) do
-    case CogApi.group_remove(client, group_name, :groups, group_to_remove) do
+  defp do_remove(endpoint, group_name, :undefined, group_to_remove) do
+    case CogApi.HTTP.Old.group_remove(endpoint, group_name, :groups, group_to_remove) do
       {:ok, resp} ->
         group = resp["group"]
 
@@ -55,7 +55,7 @@ defmodule Cogctl.Actions.Groups.Remove do
     end
   end
 
-  defp do_remove(_client, _group_name, _user_to_add, _group_to_add) do
+  defp do_remove(_endpoint, _group_name, _user_to_add, _group_to_add) do
     display_arguments_error
   end
 end

--- a/lib/cogctl/actions/groups/update.ex
+++ b/lib/cogctl/actions/groups/update.ex
@@ -7,22 +7,22 @@ defmodule Cogctl.Actions.Groups.Update do
      {:name, :undefined, 'name', {:string, :undefined}, 'Name'}]
   end
 
-  def run(options, _args, _config, client) do
+  def run(options, _args, _config, endpoint) do
     params = convert_to_params(options, [name: :optional])
-    with_authentication(client,
+    with_authentication(endpoint,
                         &do_update(&1, :proplists.get_value(:group, options), params))
   end
 
-  defp do_update(_client, :undefined, _options) do
+  defp do_update(_endpoint, :undefined, _options) do
     display_arguments_error
   end
 
-  defp do_update(_client, _group_name, :error) do
+  defp do_update(_endpoint, _group_name, :error) do
     display_arguments_error
   end
 
-  defp do_update(client, group_name, {:ok, params}) do
-    case CogApi.group_update(client, group_name, %{group: params}) do
+  defp do_update(endpoint, group_name, {:ok, params}) do
+    case CogApi.HTTP.Old.group_update(endpoint, group_name, %{group: params}) do
       {:ok, resp} ->
         group = resp["group"]
         group_attrs = for {title, attr} <- [{"ID", "id"}, {"Name", "name"}] do
@@ -35,7 +35,7 @@ defmodule Cogctl.Actions.Groups.Update do
         #{Table.format(group_attrs, false)}
         """ |> String.rstrip)
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/permissions.ex
+++ b/lib/cogctl/actions/permissions.ex
@@ -8,20 +8,21 @@ defmodule Cogctl.Actions.Permissions do
      {:role, :undefined, 'role', {:string, :undefined}, 'Name of role to filter permissions by'}]
   end
 
-  def run(options, _args, _config, client) do
+  def run(options, _args, _config, endpoint) do
     params = convert_to_params(options, [user: :optional, group: :optional, role: :optional])
-    with_authentication(client,
+    with_authentication(endpoint,
                         &do_list(&1, params))
   end
 
-  defp do_list(_client, :error) do
+  defp do_list(_endpoint, :error) do
     display_arguments_error
   end
 
-  defp do_list(client, {:ok, params}) do
-    case CogApi.permission_index(client, params) do
+  defp do_list(endpoint, {:ok, params}) do
+    case CogApi.HTTP.Old.permission_index(endpoint, params) do
       {:ok, resp} ->
         permissions = resp["permissions"]
+
         permission_attrs = for permission <- permissions do
           namespace_name = permission["namespace"]["name"]
           permission_name = permission["name"]
@@ -31,7 +32,7 @@ defmodule Cogctl.Actions.Permissions do
 
         display_output(Table.format([["NAME", "ID"]] ++ permission_attrs, true))
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/permissions/create.ex
+++ b/lib/cogctl/actions/permissions/create.ex
@@ -5,25 +5,25 @@ defmodule Cogctl.Actions.Permissions.Create do
     [{:name, :undefined, :undefined, {:string, :undefined}, 'Permission name (required)'}]
   end
 
-  def run(options, _args, _config, client) do
-    with_authentication(client,
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
                         &do_create(&1, :proplists.get_value(:name, options)))
   end
 
-  defp do_create(_client, :undefined) do
+  defp do_create(_endpoint, :undefined) do
     display_arguments_error
   end
 
-  defp do_create(client, "site:" <> name) do
-    case CogApi.permission_create(client, %{permission: %{name: name}}) do
+  defp do_create(endpoint, "site:" <> name) do
+    case CogApi.HTTP.Old.permission_create(endpoint, %{permission: %{name: name}}) do
       {:ok, _resp} ->
         display_output("Created site:#{name}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_create(_client, _name) do
+  defp do_create(_endpoint, _name) do
     display_error("Permissions must be created under the site namespace. e.g. site:deploy_blog")
   end
 end

--- a/lib/cogctl/actions/permissions/delete.ex
+++ b/lib/cogctl/actions/permissions/delete.ex
@@ -5,25 +5,25 @@ defmodule Cogctl.Actions.Permissions.Delete do
     [{:permission, :undefined, :undefined, {:string, :undefined}, 'Permission name (required)'}]
   end
 
-  def run(options, _args, _config, client) do
-    with_authentication(client,
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
                         &do_delete(&1, :proplists.get_value(:permission, options)))
   end
 
-  defp do_delete(_client, :undefined) do
+  defp do_delete(_endpoint, :undefined) do
     display_arguments_error
   end
 
-  defp do_delete(client, "site:" <> name) do
-    case CogApi.permission_delete(client, name) do
+  defp do_delete(endpoint, "site:" <> name) do
+    case CogApi.HTTP.Old.permission_delete(endpoint, name) do
       :ok ->
         display_output("Deleted site:#{name}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_delete(_client, _name) do
+  defp do_delete(_endpoint, _name) do
     {:error, "Only permissions under the site namespace can be deleted. e.g. site:deploy_blog"}
   end
 end

--- a/lib/cogctl/actions/permissions/grant.ex
+++ b/lib/cogctl/actions/permissions/grant.ex
@@ -8,52 +8,52 @@ defmodule Cogctl.Actions.Permissions.Grant do
      {:role_to_grant, :undefined, 'role', {:string, :undefined}, 'Role to grant permission'}]
   end
 
-  def run(options, _args, _config, client) do
+  def run(options, _args, _config, endpoint) do
     permission = :proplists.get_value(:permission, options)
     user_to_grant = :proplists.get_value(:user_to_grant, options)
     group_to_grant = :proplists.get_value(:group_to_grant, options)
     role_to_grant = :proplists.get_value(:role_to_grant, options)
 
-    with_authentication(client,
+    with_authentication(endpoint,
                         &do_grant(&1, permission, user_to_grant, group_to_grant, role_to_grant))
   end
 
-  defp do_grant(_client, :undefined, _user_to_grant, _group_to_grant, _role_to_grant) do
+  defp do_grant(_endpoint, :undefined, _user_to_grant, _group_to_grant, _role_to_grant) do
     display_arguments_error
   end
 
-  defp do_grant(_client, _permission, :undefined, :undefined, :undefined) do
+  defp do_grant(_endpoint, _permission, :undefined, :undefined, :undefined) do
     display_arguments_error
   end
 
-  defp do_grant(client, permission, user_to_grant, :undefined, :undefined) do
-    case CogApi.permission_grant(client, permission, "users", user_to_grant) do
+  defp do_grant(endpoint, permission, user_to_grant, :undefined, :undefined) do
+    case CogApi.HTTP.Old.permission_grant(endpoint, permission, "users", user_to_grant) do
       {:ok, _resp} ->
         display_output("Granted #{permission} to #{user_to_grant}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_grant(client, permission, :undefined, group_to_grant, :undefined) do
-    case CogApi.permission_grant(client, permission, "groups", group_to_grant) do
+  defp do_grant(endpoint, permission, :undefined, group_to_grant, :undefined) do
+    case CogApi.HTTP.Old.permission_grant(endpoint, permission, "groups", group_to_grant) do
       {:ok, _resp} ->
         display_output("Granted #{permission} to #{group_to_grant}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_grant(client, permission, :undefined, :undefined, role_to_grant) do
-    case CogApi.permission_grant(client, permission, "roles", role_to_grant) do
+  defp do_grant(endpoint, permission, :undefined, :undefined, role_to_grant) do
+    case CogApi.HTTP.Old.permission_grant(endpoint, permission, "roles", role_to_grant) do
       {:ok, _resp} ->
         display_output("Granted #{permission} to #{role_to_grant}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_grant(_client, _permission, _user_to_grant, _group_to_grant, _role_to_grant) do
+  defp do_grant(_endpoint, _permission, _user_to_grant, _group_to_grant, _role_to_grant) do
     display_arguments_error
   end
 end

--- a/lib/cogctl/actions/permissions/revoke.ex
+++ b/lib/cogctl/actions/permissions/revoke.ex
@@ -8,52 +8,52 @@ defmodule Cogctl.Actions.Permissions.Revoke do
      {:role_to_revoke, :undefined, 'role', {:string, :undefined}, 'Role to revoke permission from'}]
   end
 
-  def run(options, _args, _config, client) do
+  def run(options, _args, _config, endpoint) do
     permission = :proplists.get_value(:permission, options)
     user_to_revoke = :proplists.get_value(:user_to_revoke, options)
     group_to_revoke = :proplists.get_value(:group_to_revoke, options)
     role_to_revoke = :proplists.get_value(:role_to_revoke, options)
 
-    with_authentication(client,
+    with_authentication(endpoint,
                         &do_revoke(&1, permission, user_to_revoke, group_to_revoke, role_to_revoke))
   end
 
-  defp do_revoke(_client, :undefined, _user_to_revoke, _group_to_revoke, _role_to_revoke) do
+  defp do_revoke(_endpoint, :undefined, _user_to_revoke, _group_to_revoke, _role_to_revoke) do
     display_arguments_error
   end
 
-  defp do_revoke(_client, _permission, :undefined, :undefined, :undefined) do
+  defp do_revoke(_endpoint, _permission, :undefined, :undefined, :undefined) do
     display_arguments_error
   end
 
-  defp do_revoke(client, permission, user_to_revoke, :undefined, :undefined) do
-    case CogApi.permission_revoke(client, permission, "users", user_to_revoke) do
+  defp do_revoke(endpoint, permission, user_to_revoke, :undefined, :undefined) do
+    case CogApi.HTTP.Old.permission_revoke(endpoint, permission, "users", user_to_revoke) do
       {:ok, _resp} ->
         display_output("Revoked #{permission} from #{user_to_revoke}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_revoke(client, permission, :undefined, group_to_revoke, :undefined) do
-    case CogApi.permission_revoke(client, permission, "groups", group_to_revoke) do
+  defp do_revoke(endpoint, permission, :undefined, group_to_revoke, :undefined) do
+    case CogApi.HTTP.Old.permission_revoke(endpoint, permission, "groups", group_to_revoke) do
       {:ok, _resp} ->
         display_output("Revoked #{permission} from #{group_to_revoke}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_revoke(client, permission, :undefined, :undefined, role_to_revoke) do
-    case CogApi.permission_revoke(client, permission, "roles", role_to_revoke) do
+  defp do_revoke(endpoint, permission, :undefined, :undefined, role_to_revoke) do
+    case CogApi.HTTP.Old.permission_revoke(endpoint, permission, "roles", role_to_revoke) do
       {:ok, _resp} ->
         display_output("Revoked #{permission} from #{role_to_revoke}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_revoke(_client, _permission, _user_to_revoke, _group_to_revoke, _role_to_revoke) do
+  defp do_revoke(_endpoint, _permission, _user_to_revoke, _group_to_revoke, _role_to_revoke) do
     display_arguments_error
   end
 end

--- a/lib/cogctl/actions/roles.ex
+++ b/lib/cogctl/actions/roles.ex
@@ -6,20 +6,20 @@ defmodule Cogctl.Actions.Roles do
     []
   end
 
-  def run(_options, _args, _config, client),
-    do: with_authentication(client, &do_list/1)
+  def run(_options, _args, _config, endpoint),
+    do: with_authentication(endpoint, &do_list/1)
 
-  defp do_list(client) do
-    case CogApi.role_index(client) do
-      {:ok, resp} ->
-        roles = resp["roles"]
+  defp do_list(endpoint) do
+    case CogApi.HTTP.Roles.role_index(endpoint) do
+      {:ok, roles} ->
+
         role_attrs = for role <- roles do
-          [role["name"], role["id"]]
+          [Map.fetch!(role, :name), Map.fetch!(role, :id)]
         end
 
         display_output(Table.format([["NAME", "ID"]] ++ role_attrs, true))
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error)
     end
   end
 end

--- a/lib/cogctl/actions/roles/create.ex
+++ b/lib/cogctl/actions/roles/create.ex
@@ -6,23 +6,22 @@ defmodule Cogctl.Actions.Roles.Create do
     [{:name, :undefined, 'name', {:string, :undefined}, 'Role name (required)'}]
   end
 
-  def run(options, _args, _config, client) do
-    with_authentication(client,
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
                         &do_create(&1, :proplists.get_value(:name, options)))
   end
 
-  defp do_create(_client, :undefined) do
+  defp do_create(_endpoint, :undefined) do
     display_arguments_error
   end
 
-  defp do_create(client, name) do
-    case CogApi.role_create(client, %{role: %{name: name}}) do
-      {:ok, resp} ->
-        role = resp["role"]
-        name = role["name"]
+  defp do_create(endpoint, name) do
+    case CogApi.HTTP.Roles.role_create(endpoint, %{name: name}) do
+      {:ok, role} ->
+        name = role.name
 
-        role_attrs = for {title, attr} <- [{"ID", "id"}, {"Name", "name"}] do
-          [title, role[attr]]
+        role_attrs = for {title, attr} <- [{"ID", :id}, {"Name", :name}] do
+          [title, Map.fetch!(role, attr)]
         end
 
         display_output("""
@@ -31,7 +30,7 @@ defmodule Cogctl.Actions.Roles.Create do
         #{Table.format(role_attrs, false)}
         """ |> String.rstrip)
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error)
     end
   end
 end

--- a/lib/cogctl/actions/roles/delete.ex
+++ b/lib/cogctl/actions/roles/delete.ex
@@ -5,21 +5,21 @@ defmodule Cogctl.Actions.Roles.Delete do
     [{:role, :undefined, :undefined, {:string, :undefined}, 'Role name (required)'}]
   end
 
-  def run(options, _args, _config, client) do
-    with_authentication(client,
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
                         &do_delete(&1, :proplists.get_value(:role, options)))
   end
 
-  defp do_delete(_client, :undefined) do
+  defp do_delete(_endpoint, :undefined) do
     display_arguments_error
   end
 
-  defp do_delete(client, role_name) do
-    case CogApi.role_delete(client, role_name) do
+  defp do_delete(endpoint, role_name) do
+    case CogApi.HTTP.Old.role_delete(endpoint, role_name) do
       :ok ->
         display_output("Deleted #{role_name}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/roles/grant.ex
+++ b/lib/cogctl/actions/roles/grant.ex
@@ -7,42 +7,42 @@ defmodule Cogctl.Actions.Roles.Grant do
      {:group_to_grant, :undefined, 'group', {:string, :undefined}, 'Name of group to grant role'}]
   end
 
-  def run(options, _args, _config, client) do
+  def run(options, _args, _config, endpoint) do
     role = :proplists.get_value(:role, options)
     user_to_grant = :proplists.get_value(:user_to_grant, options)
     group_to_grant = :proplists.get_value(:group_to_grant, options)
 
-    with_authentication(client,
+    with_authentication(endpoint,
                         &do_grant(&1, role, user_to_grant, group_to_grant))
   end
 
-  defp do_grant(_client, :undefined, _user_to_grant, _group_to_grant) do
+  defp do_grant(_endpoint, :undefined, _user_to_grant, _group_to_grant) do
     display_arguments_error
   end
 
-  defp do_grant(_client, _role, :undefined, :undefined) do
+  defp do_grant(_endpoint, _role, :undefined, :undefined) do
     display_arguments_error
   end
 
-  defp do_grant(client, role, user_to_grant, :undefined) do
-    case CogApi.role_grant(client, role, "users", user_to_grant) do
+  defp do_grant(endpoint, role, user_to_grant, :undefined) do
+    case CogApi.HTTP.Old.role_grant(endpoint, role, "users", user_to_grant) do
       {:ok, _resp} ->
         display_output("Granted #{role} to #{user_to_grant}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_grant(client, role, :undefined, group_to_grant) do
-    case CogApi.role_grant(client, role, "groups", group_to_grant) do
+  defp do_grant(endpoint, role, :undefined, group_to_grant) do
+    case CogApi.HTTP.Old.role_grant(endpoint, role, "groups", group_to_grant) do
       {:ok, _resp} ->
         display_output("Granted #{role} to #{group_to_grant}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_grant(_client, _role, _user_to_grant, _group_to_grant) do
+  defp do_grant(_endpoint, _role, _user_to_grant, _group_to_grant) do
     display_arguments_error
   end
 end

--- a/lib/cogctl/actions/roles/info.ex
+++ b/lib/cogctl/actions/roles/info.ex
@@ -1,0 +1,49 @@
+defmodule Cogctl.Actions.Roles.Info do
+  use Cogctl.Action, "roles info"
+  alias Cogctl.Table
+
+  def option_spec do
+    [{:role, :undefined, :undefined, {:string, :undefined}, 'Role name (required)'}]
+  end
+
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
+                        &do_info(&1, :proplists.get_value(:role, options)))
+  end
+
+  defp do_info(_endpoint, :undefined) do
+    display_arguments_error
+  end
+
+  defp do_info(endpoint, role_name) do
+    # TODO: This will change once the latest versions of of CogApi have completed
+    #  testing and CogApi.role_show has been added to the CogApi. This will be
+    #  completed in a separate PR.
+    case CogApi.HTTP.Roles.role_index(endpoint) do
+      {:ok, resp} ->
+        roles = resp["roles"]
+        filtered_roles = Enum.filter(roles, fn(role) -> role["name"] == role_name end)
+
+        for role <- filtered_roles do
+          role_attrs = [[role["name"], role["id"]]]
+
+          permissions = role["permissions"]
+          permission_attrs = Enum.reduce(Map.keys(permissions), [], fn(ns, acc) ->
+              acc ++ Enum.map(permissions[ns], fn(perm) ->
+                [ns, perm["name"], perm["id"]]
+            end)
+          end)
+
+          display_output("""
+                         #{Table.format([["NAME", "ID"]] ++ role_attrs, false)}
+
+                         Permissions
+                         #{Table.format([["NAMESPACE", "NAME", "ID"]] ++ permission_attrs, true)}
+                         """ |> String.rstrip)
+        end
+
+      {:error, error} ->
+        display_error(error["errors"])
+    end
+  end
+end

--- a/lib/cogctl/actions/roles/revoke.ex
+++ b/lib/cogctl/actions/roles/revoke.ex
@@ -7,42 +7,42 @@ defmodule Cogctl.Actions.Roles.Revoke do
      {:group_to_revoke, :undefined, 'group', {:string, :undefined}, 'Name of group to revoke role from'}]
   end
 
-  def run(options, _args, _config, client) do
+  def run(options, _args, _config, endpoint) do
     role = :proplists.get_value(:role, options)
     user_to_revoke = :proplists.get_value(:user_to_revoke, options)
     group_to_revoke = :proplists.get_value(:group_to_revoke, options)
 
-    with_authentication(client,
+    with_authentication(endpoint,
                         &do_revoke(&1, role, user_to_revoke, group_to_revoke))
   end
 
-  defp do_revoke(_client, :undefined, _user_to_revoke, _group_to_revoke) do
+  defp do_revoke(_endpoint, :undefined, _user_to_revoke, _group_to_revoke) do
     display_arguments_error
   end
 
-  defp do_revoke(_client, _role, :undefined, :undefined) do
+  defp do_revoke(_endpoint, _role, :undefined, :undefined) do
     display_arguments_error
   end
 
-  defp do_revoke(client, role, user_to_revoke, :undefined) do
-    case CogApi.role_revoke(client, role, "users", user_to_revoke) do
+  defp do_revoke(endpoint, role, user_to_revoke, :undefined) do
+    case CogApi.HTTP.Old.role_revoke(endpoint, role, "users", user_to_revoke) do
       {:ok, _resp} ->
         display_output("Revoked #{role} from #{user_to_revoke}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_revoke(client, role, :undefined, group_to_revoke) do
-    case CogApi.role_revoke(client, role, "groups", group_to_revoke) do
+  defp do_revoke(endpoint, role, :undefined, group_to_revoke) do
+    case CogApi.HTTP.Old.role_revoke(endpoint, role, "groups", group_to_revoke) do
       {:ok, _resp} ->
         display_output("Revoked #{role} from #{group_to_revoke}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 
-  defp do_revoke(_client, _role, _user_to_revoke, _group_to_revoke) do
+  defp do_revoke(_endpoint, _role, _user_to_revoke, _group_to_revoke) do
     display_arguments_error
   end
 end

--- a/lib/cogctl/actions/roles/update.ex
+++ b/lib/cogctl/actions/roles/update.ex
@@ -7,22 +7,22 @@ defmodule Cogctl.Actions.Roles.Update do
      {:name, :undefined, 'name', {:string, :undefined}, 'Name'}]
   end
 
-  def run(options, _args, _config, client) do
+  def run(options, _args, _config, endpoint) do
     params = convert_to_params(options, [name: :optional])
-    with_authentication(client,
+    with_authentication(endpoint,
                         &do_update(&1, :proplists.get_value(:role, options), params))
   end
 
-  defp do_update(_client, :undefined, _params) do
+  defp do_update(_endpoint, :undefined, _params) do
     display_arguments_error
   end
 
-  defp do_update(_client, _role_name, :error) do
+  defp do_update(_endpoint, _role_name, :error) do
     display_arguments_error
   end
 
-  defp do_update(client, role_name, {:ok, params}) do
-    case CogApi.role_update(client, role_name, %{role: params}) do
+  defp do_update(endpoint, role_name, {:ok, params}) do
+    case CogApi.HTTP.Old.role_update(endpoint, role_name, %{role: params}) do
       {:ok, resp} ->
         role = resp["role"]
         role_attrs = for {title, attr} <- [{"ID", "id"}, {"Name", "name"}] do
@@ -35,7 +35,7 @@ defmodule Cogctl.Actions.Roles.Update do
         #{Table.format(role_attrs, false)}
         """ |> String.rstrip)
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/rules.ex
+++ b/lib/cogctl/actions/rules.ex
@@ -6,17 +6,17 @@ defmodule Cogctl.Actions.Rules do
     [{:command, :undefined, :undefined, {:string, :undefined}, 'Full command name including bundle name (required), Ex.: "operable:echo"'}]
   end
 
-  def run(options, _args, _config, client) do
-    with_authentication(client,
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
                         &do_list(&1, :proplists.get_value(:command, options)))
   end
 
-  defp do_list(_client, :undefined) do
+  defp do_list(_endpoint, :undefined) do
     display_arguments_error
   end
 
-  defp do_list(client, command) do
-    case CogApi.rule_index(client, command) do
+  defp do_list(endpoint, command) do
+    case CogApi.HTTP.Old.rule_index(endpoint, command) do
       {:ok, resp} ->
         rules = resp["rules"]
         rule_attrs = for rule <- rules do

--- a/lib/cogctl/actions/rules/create.ex
+++ b/lib/cogctl/actions/rules/create.ex
@@ -6,17 +6,17 @@ defmodule Cogctl.Actions.Rules.Create do
     [{:rule_text, ?r, 'rule-text', {:string, :undefined}, 'Text of the rule (required)'}]
   end
 
-  def run(options, _args, _config, client) do
-    with_authentication(client,
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
                         &do_create(&1, :proplists.get_value(:rule_text, options)))
   end
 
-  defp do_create(_client, :undefined) do
+  defp do_create(_endpoint, :undefined) do
     display_arguments_error
   end
 
-  defp do_create(client, rule_text) do
-    case CogApi.rule_create(client, %{rule: rule_text}) do
+  defp do_create(endpoint, rule_text) do
+    case CogApi.HTTP.Old.rule_create(endpoint, %{rule: rule_text}) do
       {:ok, resp} ->
         rule = resp["rule"]
         rule_attrs = [{"ID", resp["id"]}, {"Rule Text", rule}]
@@ -27,7 +27,7 @@ defmodule Cogctl.Actions.Rules.Create do
         #{Table.format(rule_attrs, false)}
         """ |> String.rstrip)
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/rules/delete.ex
+++ b/lib/cogctl/actions/rules/delete.ex
@@ -5,17 +5,17 @@ defmodule Cogctl.Actions.Rules.Delete do
     [{:rule, :undefined, :undefined, {:string, :undefined}, 'Rule id'}]
   end
 
-  def run(options, _args, _config, client) do
-    with_authentication(client,
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
                         &do_delete(&1, :proplists.get_value(:rule, options)))
   end
 
-  defp do_delete(_client, :undefined) do
+  defp do_delete(_endpoint, :undefined) do
     display_arguments_error
   end
 
-  defp do_delete(client, rule_id) do
-    case CogApi.rule_delete(client, rule_id) do
+  defp do_delete(endpoint, rule_id) do
+    case CogApi.HTTP.Old.rule_delete(endpoint, rule_id) do
       :ok ->
         display_output("Deleted #{rule_id}")
       {:error, error} ->

--- a/lib/cogctl/actions/users.ex
+++ b/lib/cogctl/actions/users.ex
@@ -6,11 +6,11 @@ defmodule Cogctl.Actions.Users do
     []
   end
 
-  def run(_options, _args, _config, client),
-    do: with_authentication(client, &do_list/1)
+  def run(_options, _args, _config, endpoint),
+    do: with_authentication(endpoint, &do_list/1)
 
-  defp do_list(client) do
-    case CogApi.user_index(client) do
+  defp do_list(endpoint) do
+    case CogApi.HTTP.Old.user_index(endpoint) do
       {:ok, resp} ->
         users = resp["users"]
         user_attrs = for user <- users do
@@ -19,7 +19,7 @@ defmodule Cogctl.Actions.Users do
 
         display_output(Table.format([["USERNAME", "FULL NAME"]] ++ user_attrs, true))
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/users/create.ex
+++ b/lib/cogctl/actions/users/create.ex
@@ -2,7 +2,7 @@ defmodule Cogctl.Actions.Users.Create do
   use Cogctl.Action, "users create"
   alias Cogctl.Table
 
-  # Whitelisted options passed as params to api client
+  # Whitelisted options passed as params to api endpoint
   @params [:first_name, :last_name, :email_address, :username, :password]
 
   def option_spec do
@@ -13,22 +13,22 @@ defmodule Cogctl.Actions.Users.Create do
      {:password, :undefined, 'password', {:string, :undefined}, 'Password (required)'}]
   end
 
-  def run(options, _args, _config, client) do
+  def run(options, _args, _config, endpoint) do
     params = convert_to_params(options, [first_name: :required,
                                          last_name: :required,
                                          email_address: :required,
                                          username: :required,
                                          password: :required])
 
-    with_authentication(client, &do_create(&1, params))
+    with_authentication(endpoint, &do_create(&1, params))
   end
 
-  defp do_create(_client, :error) do
+  defp do_create(_endpoint, :error) do
     display_arguments_error
   end
 
-  defp do_create(client, {:ok, params}) do
-    case CogApi.user_create(client, %{user: params}) do
+  defp do_create(endpoint, {:ok, params}) do
+    case CogApi.HTTP.Old.user_create(endpoint, %{user: params}) do
       {:ok, resp} ->
         user = resp["user"]
         username = user["username"]
@@ -43,7 +43,7 @@ defmodule Cogctl.Actions.Users.Create do
         #{Table.format(user_attrs, false)}
         """ |> String.rstrip)
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/users/delete.ex
+++ b/lib/cogctl/actions/users/delete.ex
@@ -5,21 +5,21 @@ defmodule Cogctl.Actions.Users.Delete do
     [{:user, :undefined, :undefined, {:string, :undefined}, 'Username'}]
   end
 
-  def run(options, _args, _config, client) do
-    with_authentication(client,
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
                         &do_delete(&1, :proplists.get_value(:user, options)))
   end
 
-  defp do_delete(_client, :undefined) do
+  defp do_delete(_endpoint, :undefined) do
     display_arguments_error
   end
 
-  defp do_delete(client, user_username) do
-    case CogApi.user_delete(client, user_username) do
+  defp do_delete(endpoint, user_username) do
+    case CogApi.HTTP.Old.user_delete(endpoint, user_username) do
       :ok ->
         display_output("Deleted #{user_username}")
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/users/info.ex
+++ b/lib/cogctl/actions/users/info.ex
@@ -6,17 +6,17 @@ defmodule Cogctl.Actions.Users.Info do
     [{:user, :undefined, :undefined, {:string, :undefined}, 'User username (required)'}]
   end
 
-  def run(options, _args, _config, client) do
-    with_authentication(client,
+  def run(options, _args, _config, endpoint) do
+    with_authentication(endpoint,
                         &do_info(&1, :proplists.get_value(:user, options)))
   end
 
-  defp do_info(_client, :undefined) do
+  defp do_info(_endpoint, :undefined) do
     display_arguments_error
   end
 
-  defp do_info(client, user_username) do
-    case CogApi.user_show(client, user_username) do
+  defp do_info(endpoint, user_username) do
+    case CogApi.HTTP.Old.user_show(endpoint, user_username) do
       {:ok, resp} ->
         user = resp["user"]
 
@@ -26,7 +26,7 @@ defmodule Cogctl.Actions.Users.Info do
 
         display_output(Table.format(user, false))
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/lib/cogctl/actions/users/update.ex
+++ b/lib/cogctl/actions/users/update.ex
@@ -11,23 +11,23 @@ defmodule Cogctl.Actions.Users.Update do
      {:password, :undefined, 'password', {:string, :undefined}, 'Password'}]
   end
 
-  def run(options, _args, _config, client) do
+  def run(options, _args, _config, endpoint) do
     params = convert_to_params(options, [first_name: :optional,
                                          last_name: :optional,
                                          email_address: :optional,
                                          username: :optional,
                                          password: :optional])
 
-    with_authentication(client,
+    with_authentication(endpoint,
                         &do_update(&1, :proplists.get_value(:user, options), params))
   end
 
-  defp do_update(_client, _user_username, :error) do
+  defp do_update(_endpoint, _user_username, :error) do
     display_arguments_error
   end
 
-  defp do_update(client, user_username, {:ok, params}) do
-    case CogApi.user_update(client, user_username, %{user: params}) do
+  defp do_update(endpoint, user_username, {:ok, params}) do
+    case CogApi.HTTP.Old.user_update(endpoint, user_username, %{user: params}) do
       {:ok, resp} ->
         user = resp["user"]
         username = user["username"]
@@ -42,7 +42,7 @@ defmodule Cogctl.Actions.Users.Update do
         #{Table.format(user_attrs, false)}
         """ |> String.rstrip)
       {:error, error} ->
-        display_error(error["error"])
+        display_error(error["errors"])
     end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -22,10 +22,9 @@ defmodule Cogctl.Mixfile do
     [
       {:getopt, github: "jcomellas/getopt", tag: "v0.8.2"},
       {:ibrowse, "~> 4.2.2"},
-      {:poison, "~> 1.5.0"},
       {:httpotion, "~> 2.1.0"},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client", ref: "056d00e"},
+      {:cog_api, github: "operable/cog-api-client", ref: "b4c1e5a862c01e576c32145a1393e312feb8af5f"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
-%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "056d00ee8b60b0a7632a4945fe5f5aef5b65f818", [ref: "056d00e"]},
+%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "b4c1e5a862c01e576c32145a1393e312feb8af5f", [ref: "b4c1e5a862c01e576c32145a1393e312feb8af5f"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
+  "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "getopt": {:git, "https://github.com/jcomellas/getopt.git", "388dc95caa7fb97ec7db8cfc39246a36aba61bd8", [tag: "v0.8.2"]},
   "httpotion": {:hex, :httpotion, "2.1.0"},
   "ibrowse": {:hex, :ibrowse, "4.2.2"},
-  "poison": {:hex, :poison, "1.5.0"}}
+  "poison": {:hex, :poison, "2.1.0"}}

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -20,7 +20,7 @@ defmodule CogctlTest do
     """
 
     assert run("cogctl bundles info") =~ ~r"""
-    ERROR: Missing required arguments
+    ERROR: "Missing required arguments"
     """
 
     assert run("cogctl bundles info operable") =~ ~r"""
@@ -299,7 +299,7 @@ defmodule CogctlTest do
 
   test "cogctl rules" do
     assert run("cogctl rules operable:test") =~ ~r"""
-    ERROR: No rules for command found
+    ERROR: "No rules for command found"
     """
 
     # Set up the permission

--- a/test/support/cli_case.ex
+++ b/test/support/cli_case.ex
@@ -67,7 +67,7 @@ defmodule Support.CliCase do
 
   defp ensure_started do
     case run("cogctl bootstrap") do
-      "ERROR: Already bootstrapped\n" ->
+      "ERROR: \"Already bootstrapped\"\n" ->
         :ok
       "Bootstrapped\n" ->
         :ok


### PR DESCRIPTION
Before these changes there were inconsistent structs for errors from Cog. Some structs and changesets used `:errors`, while others used `:error`. This PR changes things such that Cog uses `:errors`, which is consistent with the Ecto.changeset.

This PR also updated cogctl to use a more recent revision of CogAPI. The rev that is being referenced is located here: https://github.com/operable/cog-api-client/blob/master/CHANGELOG.md

Tests for this PR will fail until https://github.com/operable/cog/pull/441 is merged.

Fixes https://github.com/operable/cog/issues/442