### PR TITLE
Add roles info and update permissions with new format

### DIFF
--- a/lib/cogctl/actions/permissions.ex
+++ b/lib/cogctl/actions/permissions.ex
@@ -22,15 +22,11 @@ defmodule Cogctl.Actions.Permissions do
     case CogApi.HTTP.Old.permission_index(endpoint, params) do
       {:ok, resp} ->
         permissions = resp["permissions"]
+        permission_attrs = Enum.map(permissions, fn(permission) ->
+                               [permission["namespace"], permission["name"], permission["id"]]
+                           end)
 
-        permission_attrs = for permission <- permissions do
-          namespace_name = permission["namespace"]["name"]
-          permission_name = permission["name"]
-
-          ["#{namespace_name}:#{permission_name}", permission["id"]]
-        end
-
-        display_output(Table.format([["NAME", "ID"]] ++ permission_attrs, true))
+        display_output(Table.format([["NAMESPACE", "NAME", "ID"]] ++ permission_attrs, true))
       {:error, error} ->
         display_error(error["errors"])
     end

--- a/lib/cogctl/optparse.ex
+++ b/lib/cogctl/optparse.ex
@@ -20,6 +20,7 @@ defmodule Cogctl.Optparse do
                   Cogctl.Actions.Groups.Add,
                   Cogctl.Actions.Groups.Remove,
                   Cogctl.Actions.Roles,
+                  Cogctl.Actions.Roles.Info,
                   Cogctl.Actions.Roles.Create,
                   Cogctl.Actions.Roles.Update,
                   Cogctl.Actions.Roles.Delete,

--- a/mix.exs
+++ b/mix.exs
@@ -24,8 +24,7 @@ defmodule Cogctl.Mixfile do
       {:ibrowse, "~> 4.2.2"},
       {:httpotion, "~> 2.1.0"},
       {:configparser_ex, "~> 0.2.0"},
-      #{:cog_api, github: "operable/cog-api-client", ref: "87c16814dc8c5a0ca594dc80ffbc849451eb9f7b"},
-      {:cog_api, github: "operable/cog-api-client", ref: "d849cfe6d7dfec943ea1abdca59047d9934f85f0"},
+      {:cog_api, github: "operable/cog-api-client", ref: "79b1ec4eaa1eb2fa577e8a3294f054fef6b5d8c0"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "d849cfe6d7dfec943ea1abdca59047d9934f85f0", [ref: "d849cfe6d7dfec943ea1abdca59047d9934f85f0"]},
+%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "79b1ec4eaa1eb2fa577e8a3294f054fef6b5d8c0", [ref: "79b1ec4eaa1eb2fa577e8a3294f054fef6b5d8c0"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "getopt": {:git, "https://github.com/jcomellas/getopt.git", "388dc95caa7fb97ec7db8cfc39246a36aba61bd8", [tag: "v0.8.2"]},

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -245,12 +245,12 @@ defmodule CogctlTest do
 
   test "cogctl permissions" do
     assert run("cogctl permissions") =~ ~r"""
-    NAME                         ID
-    operable:manage_commands     .*
-    operable:manage_groups       .*
-    operable:manage_permissions  .*
-    operable:manage_roles        .*
-    operable:manage_users        .*
+    NAMESPACE  NAME                ID
+    operable   manage_commands     .*
+    operable   manage_groups       .*
+    operable   manage_permissions  .*
+    operable   manage_roles        .*
+    operable   manage_users        .*
     """
 
     assert run("cogctl permissions create site:echo") =~ ~r"""
@@ -273,8 +273,8 @@ defmodule CogctlTest do
     """
 
     assert run("cogctl permissions --group=ops") =~ ~r"""
-    NAME       ID
-    site:echo  .*
+    NAMESPACE  NAME  ID
+    site       echo  .*
     """
 
     assert run("cogctl roles create --name=developer") =~ ~r"""
@@ -289,8 +289,17 @@ defmodule CogctlTest do
     """
 
     assert run("cogctl permissions --role=developer") =~ ~r"""
+    NAMESPACE  NAME  ID
+    site       echo  .*
+    """
+
+    assert run("cogctl roles info developer") =~ ~r"""
     NAME       ID
-    site:echo  .*
+    developer  .*
+
+    Permissions
+    NAMESPACE  NAME  ID
+    site       echo  .*
     """
 
     assert run("cogctl permissions revoke site:echo --user=admin") =~ ~r"""


### PR DESCRIPTION
This PR
* adds the role_show api allowing for the addition of permissions info in a new permission format 
```
%{permissions: [%{namespace: "namespace1",
                               id: "some id",
                               name: "some permission"},
                              %{namespace: "namespace2",
                                  id: "some other id",
                                  name:"some other permission"}]
}
```
* adds permissions to the role model

**Tests will fail until Cog PR # is merged to master.**

Fixes https://github.com/operable/cog/issues/382