### PR TITLE
Add groups to users

### DIFF
--- a/lib/cogctl/actions/users/info.ex
+++ b/lib/cogctl/actions/users/info.ex
@@ -24,7 +24,7 @@ defmodule Cogctl.Actions.Users.Info do
           [title, user[attr]]
         end
 
-        groups = Enum.map(user["group_memberships"], fn(membership) ->
+        groups = Enum.map(user["groups"], fn(membership) ->
                    [membership["name"], membership["id"]]
                  end)
 

--- a/lib/cogctl/actions/users/info.ex
+++ b/lib/cogctl/actions/users/info.ex
@@ -20,11 +20,20 @@ defmodule Cogctl.Actions.Users.Info do
       {:ok, resp} ->
         user = resp["user"]
 
-        user = for {title, attr} <- [{"ID", "id"}, {"Username", "username"}, {"First Name", "first_name"}, {"Last Name", "last_name"}, {"Email", "email_address"}] do
+        user_attr = for {title, attr} <- [{"ID", "id"}, {"Username", "username"}, {"First Name", "first_name"}, {"Last Name", "last_name"}, {"Email", "email_address"}] do
           [title, user[attr]]
         end
 
-        display_output(Table.format(user, false))
+        groups = Enum.map(user["group_memberships"], fn(membership) ->
+                   [membership["name"], membership["id"]]
+                 end)
+
+        display_output("""
+                       #{Table.format(user_attr, false)}
+
+                       Groups
+                       #{Table.format([["NAME", "ID"]] ++ groups, true)}
+                       """ |> String.rstrip)
       {:error, error} ->
         display_error(error["errors"])
     end

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -66,6 +66,9 @@ defmodule CogctlTest do
     First Name  Cog
     Last Name   Administrator
     Email       cog@localhost
+
+    Groups
+    NAME  ID
     """
 
     output = run("""


### PR DESCRIPTION
Pulls group membership information for a user and display each group name and id.

**Tests will fail until PR https://github.com/operable/cog/pull/475 is merged to master.**

Fixes https://github.com/operable/cog/issues/474