### PR TITLE
add roles, users, and groups to groups#show and #index

### DIFF
--- a/lib/cogctl/actions/groups.ex
+++ b/lib/cogctl/actions/groups.ex
@@ -23,7 +23,7 @@ defmodule Cogctl.Actions.Groups do
     end
   end
 
-  def render_memberships(%{"members" => %{"users" => users, "groups" => groups}}) do
+  def render_memberships(%{"members" => %{"users" => users, "groups" => groups, "roles" => roles}}) do
     user_attrs = for user <- users do
       [user["username"], user["id"]]
     end
@@ -32,12 +32,19 @@ defmodule Cogctl.Actions.Groups do
       [group["name"], group["id"]]
     end
 
+    role_attrs = for role <- roles do
+      [role["name"], role["id"]]
+    end
+
     """
     User Memberships
     #{Table.format([["USERNAME", "ID"]] ++ user_attrs, true)}
 
     Group Memberships
     #{Table.format([["NAME", "ID"]] ++ group_attrs, true)}
+
+    Role Memberships
+    #{Table.format([["NAME", "ID"]] ++ role_attrs, true)}
     """ |> String.rstrip
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Cogctl.Mixfile do
       {:ibrowse, "~> 4.2.2"},
       {:httpotion, "~> 2.1.0"},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client", ref: "32bbae6485afd2c3a3d95d02f2398985f08fc92b"},
+      {:cog_api, github: "operable/cog-api-client", ref: "2badfd6b3d9de2c62d242b81112857a6e85bc982"},
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Cogctl.Mixfile do
       {:ibrowse, "~> 4.2.2"},
       {:httpotion, "~> 2.1.0"},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client", ref: "79b1ec4eaa1eb2fa577e8a3294f054fef6b5d8c0"},
+      {:cog_api, github: "operable/cog-api-client", ref: "32bbae6485afd2c3a3d95d02f2398985f08fc92b"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "79b1ec4eaa1eb2fa577e8a3294f054fef6b5d8c0", [ref: "79b1ec4eaa1eb2fa577e8a3294f054fef6b5d8c0"]},
+%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "32bbae6485afd2c3a3d95d02f2398985f08fc92b", [ref: "32bbae6485afd2c3a3d95d02f2398985f08fc92b"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "getopt": {:git, "https://github.com/jcomellas/getopt.git", "388dc95caa7fb97ec7db8cfc39246a36aba61bd8", [tag: "v0.8.2"]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "32bbae6485afd2c3a3d95d02f2398985f08fc92b", [ref: "32bbae6485afd2c3a3d95d02f2398985f08fc92b"]},
+%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "2badfd6b3d9de2c62d242b81112857a6e85bc982", [ref: "2badfd6b3d9de2c62d242b81112857a6e85bc982"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "getopt": {:git, "https://github.com/jcomellas/getopt.git", "388dc95caa7fb97ec7db8cfc39246a36aba61bd8", [tag: "v0.8.2"]},

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -166,6 +166,9 @@ defmodule CogctlTest do
 
     Group Memberships
     NAME  ID
+
+    Role Memberships
+    NAME  ID
     """
 
     assert run("cogctl groups add admin --group=devops") =~ ~r"""
@@ -178,6 +181,20 @@ defmodule CogctlTest do
     Group Memberships
     NAME    ID
     devops  .*
+
+    Role Memberships
+    NAME  ID
+    """
+
+    assert run("cogctl roles create --name=tester") =~ ~r"""
+    Created tester
+
+    ID    .*
+    Name  tester
+    """
+
+    assert run("cogctl roles grant --group=admin tester") =~ ~r"""
+    Granted tester to admin
     """
 
     assert run("cogctl groups info admin") =~ ~r"""
@@ -191,6 +208,10 @@ defmodule CogctlTest do
     Group Memberships
     NAME    ID
     devops  .*
+
+    Role Memberships
+    NAME    ID
+    tester  .*
     """
 
     assert run("cogctl groups remove admin --user=admin") =~ ~r"""
@@ -202,6 +223,14 @@ defmodule CogctlTest do
     Group Memberships
     NAME    ID
     devops  .*
+
+    Role Memberships
+    NAME    ID
+    tester  .*
+    """
+
+    assert run("cogctl roles revoke --group=admin tester") =~ ~r"""
+    Revoked tester from admin
     """
 
     assert run("cogctl groups delete devops") =~ ~r"""

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -281,6 +281,7 @@ defmodule CogctlTest do
     operable   manage_commands     .*
     operable   manage_groups       .*
     operable   manage_permissions  .*
+    operable   manage_relays       .*
     operable   manage_roles        .*
     operable   manage_users        .*
     """


### PR DESCRIPTION
This PR displays roles for the groups command. The Name and Id of the granted roles will be displayed.

**Tests will fail until PR #https://github.com/operable/cog/pull/480 is merged to master.**

Fixes https://github.com/operable/cog/issues/462