### PR TITLE
Bring cogctl up-to-date with CogApi master

### DIFF
--- a/lib/cogctl/actions/bootstrap.ex
+++ b/lib/cogctl/actions/bootstrap.ex
@@ -16,7 +16,7 @@ defmodule Cogctl.Actions.Bootstrap do
   end
 
   defp do_query(endpoint) do
-    case CogApi.HTTP.Old.bootstrap_show(endpoint) do
+    case CogApi.HTTP.Internal.bootstrap_show(endpoint) do
       {:ok, body} ->
         status = case body do
           %{"bootstrap" => %{"bootstrap_status" => true}} ->
@@ -32,7 +32,7 @@ defmodule Cogctl.Actions.Bootstrap do
   end
 
   defp do_bootstrap(endpoint, config) do
-    case CogApi.HTTP.Old.bootstrap_create(endpoint) do
+    case CogApi.HTTP.Internal.bootstrap_create(endpoint) do
       {:ok, admin} ->
         values = config.values
                  |> Map.put(endpoint.host, %{"user" => get_in(admin, ["bootstrap", "username"]),

--- a/lib/cogctl/actions/bundles.ex
+++ b/lib/cogctl/actions/bundles.ex
@@ -10,13 +10,14 @@ defmodule Cogctl.Actions.Bundles do
     do: with_authentication(endpoint, &do_list/1)
 
   defp do_list(endpoint) do
-    case CogApi.HTTP.Old.bundle_index(endpoint) do
-      {:ok, resp} ->
-        bundles = for bundle <- resp["bundles"] do
-          [bundle["name"], enabled_to_status(bundle["enabled"]), bundle["inserted_at"]]
+    case CogApi.HTTP.Bundles.index(endpoint) do
+      {:ok, bundles} ->
+
+        bundle_details = for bundle <- bundles do
+          [bundle.name, enabled_to_status(bundle.enabled), bundle.inserted_at]
         end
 
-        display_output(Table.format([["NAME", "STATUS", "INSTALLED"]] ++ bundles, true))
+        display_output(Table.format([["NAME", "STATUS", "INSTALLED"]] ++ bundle_details, true))
       {:error, error} ->
         display_error(error["errors"])
     end

--- a/lib/cogctl/actions/bundles/delete.ex
+++ b/lib/cogctl/actions/bundles/delete.ex
@@ -24,7 +24,7 @@ defmodule Cogctl.Actions.Bundles.Delete do
   end
 
   defp do_delete(endpoint, bundle_name) do
-    case CogApi.HTTP.Old.bundle_delete(endpoint, bundle_name) do
+    case CogApi.HTTP.Internal.bundle_delete(endpoint, bundle_name) do
       :ok ->
         display_output("Deleted #{bundle_name}")
       {:error, error} ->

--- a/lib/cogctl/actions/bundles/disable.ex
+++ b/lib/cogctl/actions/bundles/disable.ex
@@ -11,7 +11,7 @@ defmodule Cogctl.Actions.Bundles.Disable do
   end
 
   defp do_disable(endpoint, bundle_name) do
-    case CogApi.HTTP.Old.bundle_disable(endpoint, bundle_name) do
+    case CogApi.HTTP.Bundles.update(endpoint, %{name: bundle_name}, %{enabled: false}) do
       {:ok, _} ->
         display_output("Disabled #{bundle_name}")
       {:error, error} ->

--- a/lib/cogctl/actions/bundles/enable.ex
+++ b/lib/cogctl/actions/bundles/enable.ex
@@ -11,7 +11,7 @@ defmodule Cogctl.Actions.Bundles.Enable do
   end
 
   defp do_enable(endpoint, bundle_name) do
-    case CogApi.HTTP.Old.bundle_enable(endpoint, bundle_name) do
+    case CogApi.HTTP.Bundles.update(endpoint, %{name: bundle_name}, %{enabled: false}) do
       {:ok, _} ->
         display_output("Enabled #{bundle_name}")
       {:error, error} ->

--- a/lib/cogctl/actions/bundles/info.ex
+++ b/lib/cogctl/actions/bundles/info.ex
@@ -17,7 +17,7 @@ defmodule Cogctl.Actions.Bundles.Info do
   end
 
   defp do_info(endpoint, bundle_name) do
-    case CogApi.HTTP.Old.bundle_show(endpoint, bundle_name) do
+    case CogApi.HTTP.Internal.bundle_show(endpoint, bundle_name) do
       {:ok, resp} ->
         bundle = resp["bundle"]
 

--- a/lib/cogctl/actions/chat_handles.ex
+++ b/lib/cogctl/actions/chat_handles.ex
@@ -10,7 +10,7 @@ defmodule Cogctl.Actions.ChatHandles do
     do: with_authentication(endpoint, &do_list/1)
 
   defp do_list(endpoint) do
-    case CogApi.HTTP.Old.chat_handle_index(endpoint) do
+    case CogApi.HTTP.Internal.chat_handle_index(endpoint) do
       {:ok, resp} ->
         chat_handles = resp["chat_handles"]
         chat_handle_attrs = for chat_handle <- chat_handles do

--- a/lib/cogctl/actions/chat_handles/create.ex
+++ b/lib/cogctl/actions/chat_handles/create.ex
@@ -18,7 +18,7 @@ defmodule Cogctl.Actions.ChatHandles.Create do
   end
 
   defp do_create(endpoint, {:ok, params}) do
-    case CogApi.HTTP.Old.chat_handle_create(endpoint, %{chat_handle: params}) do
+    case CogApi.HTTP.Internal.chat_handle_create(endpoint, %{chat_handle: params}) do
       {:ok, resp} ->
         chat_handle = resp["chat_handle"]
         user = chat_handle["user"]["username"]

--- a/lib/cogctl/actions/chat_handles/delete.ex
+++ b/lib/cogctl/actions/chat_handles/delete.ex
@@ -16,7 +16,7 @@ defmodule Cogctl.Actions.ChatHandles.Delete do
   end
 
   defp do_delete(endpoint, {:ok, params}) do
-    case CogApi.HTTP.Old.chat_handle_delete(endpoint, %{chat_handle: params}) do
+    case CogApi.HTTP.Internal.chat_handle_delete(endpoint, %{chat_handle: params}) do
       :ok ->
         display_output("Deleted chat handle owned by #{params[:user]} for #{params[:chat_provider]} chat provider")
       {:error, error} ->

--- a/lib/cogctl/actions/groups.ex
+++ b/lib/cogctl/actions/groups.ex
@@ -10,11 +10,10 @@ defmodule Cogctl.Actions.Groups do
     do: with_authentication(endpoint, &do_list/1)
 
   defp do_list(endpoint) do
-    case CogApi.HTTP.Old.group_index(endpoint) do
-      {:ok, resp} ->
-        groups = resp["groups"]
+    case CogApi.HTTP.Groups.index(endpoint) do
+      {:ok, groups} ->
         group_attrs = for group <- groups do
-          [group["name"], group["id"]]
+          [group.name, group.id]
         end
 
         display_output(Table.format([["NAME", "ID"]] ++ group_attrs, true))

--- a/lib/cogctl/actions/groups/add.ex
+++ b/lib/cogctl/actions/groups/add.ex
@@ -26,7 +26,7 @@ defmodule Cogctl.Actions.Groups.Add do
   end
 
   defp do_add(endpoint, group_name, user_to_add, :undefined) do
-    case CogApi.HTTP.Old.group_add(endpoint, group_name, :users, user_to_add) do
+    case CogApi.HTTP.Internal.group_add(endpoint, group_name, :users, user_to_add) do
       {:ok, resp} ->
         group = resp["group"]
 
@@ -41,7 +41,7 @@ defmodule Cogctl.Actions.Groups.Add do
   end
 
   defp do_add(endpoint, group_name, :undefined, group_to_add) do
-    case CogApi.HTTP.Old.group_add(endpoint, group_name, :groups, group_to_add) do
+    case CogApi.HTTP.Internal.group_add(endpoint, group_name, :groups, group_to_add) do
       {:ok, resp} ->
         group = resp["group"]
 

--- a/lib/cogctl/actions/groups/create.ex
+++ b/lib/cogctl/actions/groups/create.ex
@@ -15,14 +15,13 @@ defmodule Cogctl.Actions.Groups.Create do
     display_arguments_error
   end
 
-  defp do_create(endpoint, name) do
-    case CogApi.HTTP.Old.group_create(endpoint, %{group: %{name: name}}) do
-      {:ok, resp} ->
-        group = resp["group"]
-        name = group["name"]
+  defp do_create(endpoint, group_name) do
+    case CogApi.HTTP.Groups.create(endpoint, %{name: group_name}) do
+      {:ok, group} ->
+        name = group.name
 
-        group_attrs = for {title, attr} <- [{"ID", "id"}, {"Name", "name"}] do
-          [title, group[attr]]
+        group_attrs = for {title, attr} <- [{"ID", :id}, {"Name", :name}] do
+          [title, Map.fetch!(group, attr)]
         end
 
         display_output("""

--- a/lib/cogctl/actions/groups/delete.ex
+++ b/lib/cogctl/actions/groups/delete.ex
@@ -15,7 +15,7 @@ defmodule Cogctl.Actions.Groups.Delete do
   end
 
   defp do_delete(endpoint, group_name) do
-    case CogApi.HTTP.Old.group_delete(endpoint, group_name) do
+    case CogApi.HTTP.Internal.group_delete(endpoint, group_name) do
       :ok ->
         display_output("Deleted #{group_name}")
       {:error, error} ->

--- a/lib/cogctl/actions/groups/info.ex
+++ b/lib/cogctl/actions/groups/info.ex
@@ -17,7 +17,7 @@ defmodule Cogctl.Actions.Groups.Info do
   end
 
   defp do_info(endpoint, group_name) do
-    case CogApi.HTTP.Old.group_show(endpoint, group_name) do
+    case CogApi.HTTP.Internal.group_show(endpoint, group_name) do
       {:ok, resp} ->
         group = resp["group"]
 

--- a/lib/cogctl/actions/groups/remove.ex
+++ b/lib/cogctl/actions/groups/remove.ex
@@ -26,7 +26,7 @@ defmodule Cogctl.Actions.Groups.Remove do
   end
 
   defp do_remove(endpoint, group_name, user_to_remove, :undefined) do
-    case CogApi.HTTP.Old.group_remove(endpoint, group_name, :users, user_to_remove) do
+    case CogApi.HTTP.Internal.group_remove(endpoint, group_name, :users, user_to_remove) do
       {:ok, resp} ->
         group = resp["group"]
 
@@ -41,7 +41,7 @@ defmodule Cogctl.Actions.Groups.Remove do
   end
 
   defp do_remove(endpoint, group_name, :undefined, group_to_remove) do
-    case CogApi.HTTP.Old.group_remove(endpoint, group_name, :groups, group_to_remove) do
+    case CogApi.HTTP.Internal.group_remove(endpoint, group_name, :groups, group_to_remove) do
       {:ok, resp} ->
         group = resp["group"]
 

--- a/lib/cogctl/actions/groups/update.ex
+++ b/lib/cogctl/actions/groups/update.ex
@@ -22,7 +22,7 @@ defmodule Cogctl.Actions.Groups.Update do
   end
 
   defp do_update(endpoint, group_name, {:ok, params}) do
-    case CogApi.HTTP.Old.group_update(endpoint, group_name, %{group: params}) do
+    case CogApi.HTTP.Internal.group_update(endpoint, group_name, %{group: params}) do
       {:ok, resp} ->
         group = resp["group"]
         group_attrs = for {title, attr} <- [{"ID", "id"}, {"Name", "name"}] do

--- a/lib/cogctl/actions/permissions.ex
+++ b/lib/cogctl/actions/permissions.ex
@@ -19,7 +19,7 @@ defmodule Cogctl.Actions.Permissions do
   end
 
   defp do_list(endpoint, {:ok, params}) do
-    case CogApi.HTTP.Old.permission_index(endpoint, params) do
+    case CogApi.HTTP.Internal.permission_index(endpoint, params) do
       {:ok, resp} ->
         permissions = resp["permissions"]
         permission_attrs = Enum.map(permissions, fn(permission) ->

--- a/lib/cogctl/actions/permissions/create.ex
+++ b/lib/cogctl/actions/permissions/create.ex
@@ -15,7 +15,7 @@ defmodule Cogctl.Actions.Permissions.Create do
   end
 
   defp do_create(endpoint, "site:" <> name) do
-    case CogApi.HTTP.Old.permission_create(endpoint, %{permission: %{name: name}}) do
+    case CogApi.HTTP.Permissions.create(endpoint, name) do
       {:ok, _resp} ->
         display_output("Created site:#{name}")
       {:error, error} ->

--- a/lib/cogctl/actions/permissions/delete.ex
+++ b/lib/cogctl/actions/permissions/delete.ex
@@ -15,7 +15,7 @@ defmodule Cogctl.Actions.Permissions.Delete do
   end
 
   defp do_delete(endpoint, "site:" <> name) do
-    case CogApi.HTTP.Old.permission_delete(endpoint, name) do
+    case CogApi.HTTP.Internal.permission_delete(endpoint, name) do
       :ok ->
         display_output("Deleted site:#{name}")
       {:error, error} ->

--- a/lib/cogctl/actions/permissions/grant.ex
+++ b/lib/cogctl/actions/permissions/grant.ex
@@ -27,7 +27,7 @@ defmodule Cogctl.Actions.Permissions.Grant do
   end
 
   defp do_grant(endpoint, permission, user_to_grant, :undefined, :undefined) do
-    case CogApi.HTTP.Old.permission_grant(endpoint, permission, "users", user_to_grant) do
+    case CogApi.HTTP.Internal.permission_grant(endpoint, permission, "users", user_to_grant) do
       {:ok, _resp} ->
         display_output("Granted #{permission} to #{user_to_grant}")
       {:error, error} ->
@@ -36,7 +36,7 @@ defmodule Cogctl.Actions.Permissions.Grant do
   end
 
   defp do_grant(endpoint, permission, :undefined, group_to_grant, :undefined) do
-    case CogApi.HTTP.Old.permission_grant(endpoint, permission, "groups", group_to_grant) do
+    case CogApi.HTTP.Internal.permission_grant(endpoint, permission, "groups", group_to_grant) do
       {:ok, _resp} ->
         display_output("Granted #{permission} to #{group_to_grant}")
       {:error, error} ->
@@ -45,7 +45,7 @@ defmodule Cogctl.Actions.Permissions.Grant do
   end
 
   defp do_grant(endpoint, permission, :undefined, :undefined, role_to_grant) do
-    case CogApi.HTTP.Old.permission_grant(endpoint, permission, "roles", role_to_grant) do
+    case CogApi.HTTP.Internal.permission_grant(endpoint, permission, "roles", role_to_grant) do
       {:ok, _resp} ->
         display_output("Granted #{permission} to #{role_to_grant}")
       {:error, error} ->

--- a/lib/cogctl/actions/permissions/revoke.ex
+++ b/lib/cogctl/actions/permissions/revoke.ex
@@ -27,7 +27,7 @@ defmodule Cogctl.Actions.Permissions.Revoke do
   end
 
   defp do_revoke(endpoint, permission, user_to_revoke, :undefined, :undefined) do
-    case CogApi.HTTP.Old.permission_revoke(endpoint, permission, "users", user_to_revoke) do
+    case CogApi.HTTP.Internal.permission_revoke(endpoint, permission, "users", user_to_revoke) do
       {:ok, _resp} ->
         display_output("Revoked #{permission} from #{user_to_revoke}")
       {:error, error} ->
@@ -36,7 +36,7 @@ defmodule Cogctl.Actions.Permissions.Revoke do
   end
 
   defp do_revoke(endpoint, permission, :undefined, group_to_revoke, :undefined) do
-    case CogApi.HTTP.Old.permission_revoke(endpoint, permission, "groups", group_to_revoke) do
+    case CogApi.HTTP.Internal.permission_revoke(endpoint, permission, "groups", group_to_revoke) do
       {:ok, _resp} ->
         display_output("Revoked #{permission} from #{group_to_revoke}")
       {:error, error} ->
@@ -45,7 +45,7 @@ defmodule Cogctl.Actions.Permissions.Revoke do
   end
 
   defp do_revoke(endpoint, permission, :undefined, :undefined, role_to_revoke) do
-    case CogApi.HTTP.Old.permission_revoke(endpoint, permission, "roles", role_to_revoke) do
+    case CogApi.HTTP.Internal.permission_revoke(endpoint, permission, "roles", role_to_revoke) do
       {:ok, _resp} ->
         display_output("Revoked #{permission} from #{role_to_revoke}")
       {:error, error} ->

--- a/lib/cogctl/actions/roles.ex
+++ b/lib/cogctl/actions/roles.ex
@@ -10,7 +10,7 @@ defmodule Cogctl.Actions.Roles do
     do: with_authentication(endpoint, &do_list/1)
 
   defp do_list(endpoint) do
-    case CogApi.HTTP.Roles.role_index(endpoint) do
+    case CogApi.HTTP.Roles.index(endpoint) do
       {:ok, roles} ->
 
         role_attrs = for role <- roles do

--- a/lib/cogctl/actions/roles/create.ex
+++ b/lib/cogctl/actions/roles/create.ex
@@ -16,7 +16,7 @@ defmodule Cogctl.Actions.Roles.Create do
   end
 
   defp do_create(endpoint, name) do
-    case CogApi.HTTP.Roles.role_create(endpoint, %{name: name}) do
+    case CogApi.HTTP.Roles.create(endpoint, %{name: name}) do
       {:ok, role} ->
         name = role.name
 

--- a/lib/cogctl/actions/roles/delete.ex
+++ b/lib/cogctl/actions/roles/delete.ex
@@ -15,7 +15,7 @@ defmodule Cogctl.Actions.Roles.Delete do
   end
 
   defp do_delete(endpoint, role_name) do
-    case CogApi.HTTP.Old.role_delete(endpoint, role_name) do
+    case CogApi.HTTP.Internal.role_delete(endpoint, role_name) do
       :ok ->
         display_output("Deleted #{role_name}")
       {:error, error} ->

--- a/lib/cogctl/actions/roles/grant.ex
+++ b/lib/cogctl/actions/roles/grant.ex
@@ -25,7 +25,7 @@ defmodule Cogctl.Actions.Roles.Grant do
   end
 
   defp do_grant(endpoint, role, user_to_grant, :undefined) do
-    case CogApi.HTTP.Old.role_grant(endpoint, role, "users", user_to_grant) do
+    case CogApi.HTTP.Internal.role_grant(endpoint, role, "users", user_to_grant) do
       {:ok, _resp} ->
         display_output("Granted #{role} to #{user_to_grant}")
       {:error, error} ->
@@ -34,7 +34,13 @@ defmodule Cogctl.Actions.Roles.Grant do
   end
 
   defp do_grant(endpoint, role, :undefined, group_to_grant) do
-    case CogApi.HTTP.Old.role_grant(endpoint, role, "groups", group_to_grant) do
+    group = with {:ok, groups} = CogApi.HTTP.Groups.index(endpoint), 
+      do: Enum.find(groups, fn(group) -> group.name == group_to_grant end)
+
+    grant_role = with {:ok, roles} = CogApi.HTTP.Roles.index(endpoint),
+      do: Enum.find(roles, fn(r) -> r.name == role end)
+
+    case CogApi.HTTP.Roles.grant(endpoint, grant_role, group) do
       {:ok, _resp} ->
         display_output("Granted #{role} to #{group_to_grant}")
       {:error, error} ->

--- a/lib/cogctl/actions/roles/info.ex
+++ b/lib/cogctl/actions/roles/info.ex
@@ -16,12 +16,12 @@ defmodule Cogctl.Actions.Roles.Info do
   end
 
   defp do_info(endpoint, role_name) do
-    case CogApi.HTTP.Roles.role_show(endpoint, role_name) do
+    case CogApi.HTTP.Roles.show(endpoint, %{name: role_name}) do
       {:ok, role} ->
         role_attrs = [[Map.fetch!(role, :name), Map.fetch!(role, :id)]]
 
         permission_attrs = Enum.map(role.permissions, fn(permission) ->
-                               [permission["namespace"], permission["name"], permission["id"]]
+                               [permission.namespace, permission.name, permission.id]
                            end)
         display_output("""
                        #{Table.format([["NAME", "ID"]] ++ role_attrs, false)}

--- a/lib/cogctl/actions/roles/update.ex
+++ b/lib/cogctl/actions/roles/update.ex
@@ -22,7 +22,7 @@ defmodule Cogctl.Actions.Roles.Update do
   end
 
   defp do_update(endpoint, role_name, {:ok, params}) do
-    case CogApi.HTTP.Old.role_update(endpoint, role_name, %{role: params}) do
+    case CogApi.HTTP.Internal.role_update(endpoint, role_name, %{role: params}) do
       {:ok, resp} ->
         role = resp["role"]
         role_attrs = for {title, attr} <- [{"ID", "id"}, {"Name", "name"}] do

--- a/lib/cogctl/actions/rules.ex
+++ b/lib/cogctl/actions/rules.ex
@@ -16,7 +16,7 @@ defmodule Cogctl.Actions.Rules do
   end
 
   defp do_list(endpoint, command) do
-    case CogApi.HTTP.Old.rule_index(endpoint, command) do
+    case CogApi.HTTP.Internal.rule_index(endpoint, command) do
       {:ok, resp} ->
         rules = resp["rules"]
         rule_attrs = for rule <- rules do

--- a/lib/cogctl/actions/rules/create.ex
+++ b/lib/cogctl/actions/rules/create.ex
@@ -16,7 +16,7 @@ defmodule Cogctl.Actions.Rules.Create do
   end
 
   defp do_create(endpoint, rule_text) do
-    case CogApi.HTTP.Old.rule_create(endpoint, %{rule: rule_text}) do
+    case CogApi.HTTP.Internal.rule_create(endpoint, %{rule: rule_text}) do
       {:ok, resp} ->
         rule = resp["rule"]
         rule_attrs = [{"ID", resp["id"]}, {"Rule Text", rule}]

--- a/lib/cogctl/actions/rules/delete.ex
+++ b/lib/cogctl/actions/rules/delete.ex
@@ -15,7 +15,7 @@ defmodule Cogctl.Actions.Rules.Delete do
   end
 
   defp do_delete(endpoint, rule_id) do
-    case CogApi.HTTP.Old.rule_delete(endpoint, rule_id) do
+    case CogApi.HTTP.Internal.rule_delete(endpoint, rule_id) do
       :ok ->
         display_output("Deleted #{rule_id}")
       {:error, error} ->

--- a/lib/cogctl/actions/users.ex
+++ b/lib/cogctl/actions/users.ex
@@ -15,11 +15,10 @@ defmodule Cogctl.Actions.Users do
   defp generate_table_row(username, first, last), do: [username, first <> " " <> last]
 
   defp do_list(endpoint) do
-    case CogApi.HTTP.Old.user_index(endpoint) do
-      {:ok, resp} ->
-        users = resp["users"]
+    case CogApi.HTTP.Users.index(endpoint) do
+      {:ok, users} ->
         user_attrs = for user <- users do
-          generate_table_row(user["username"], user["first_name"], user["last_name"])
+          generate_table_row(user.username, user.first_name, user.last_name)
         end
 
         display_output(Table.format([["USERNAME", "FULL NAME"]] ++ user_attrs, true))

--- a/lib/cogctl/actions/users/create.ex
+++ b/lib/cogctl/actions/users/create.ex
@@ -28,13 +28,12 @@ defmodule Cogctl.Actions.Users.Create do
   end
 
   defp do_create(endpoint, {:ok, params}) do
-    case CogApi.HTTP.Old.user_create(endpoint, %{user: params}) do
-      {:ok, resp} ->
-        user = resp["user"]
-        username = user["username"]
+    case CogApi.HTTP.Users.create(endpoint, params) do
+      {:ok, user} ->
+        username = user.username
 
-        user_attrs = for {title, attr} <- [{"ID", "id"}, {"Username", "username"}, {"First Name", "first_name"}, {"Last Name", "last_name"}, {"Email", "email_address"}] do
-          generate_table_row(title, user[attr])
+        user_attrs = for {title, attr} <- [{"ID", :id}, {"Username", :username}, {"First Name", :first_name}, {"Last Name", :last_name}, {"Email", :email_address}] do
+          generate_table_row(title, Map.fetch!(user, attr))
         end
 
         display_output("""

--- a/lib/cogctl/actions/users/delete.ex
+++ b/lib/cogctl/actions/users/delete.ex
@@ -15,7 +15,7 @@ defmodule Cogctl.Actions.Users.Delete do
   end
 
   defp do_delete(endpoint, user_username) do
-    case CogApi.HTTP.Old.user_delete(endpoint, user_username) do
+    case CogApi.HTTP.Internal.user_delete(endpoint, user_username) do
       :ok ->
         display_output("Deleted #{user_username}")
       {:error, error} ->

--- a/lib/cogctl/actions/users/info.ex
+++ b/lib/cogctl/actions/users/info.ex
@@ -16,7 +16,7 @@ defmodule Cogctl.Actions.Users.Info do
   end
 
   defp do_info(endpoint, user_username) do
-    case CogApi.HTTP.Old.user_show(endpoint, user_username) do
+    case CogApi.HTTP.Internal.user_show(endpoint, user_username) do
       {:ok, resp} ->
         user = resp["user"]
 

--- a/lib/cogctl/actions/users/update.ex
+++ b/lib/cogctl/actions/users/update.ex
@@ -27,7 +27,7 @@ defmodule Cogctl.Actions.Users.Update do
   end
 
   defp do_update(endpoint, user_username, {:ok, params}) do
-    case CogApi.HTTP.Old.user_update(endpoint, user_username, %{user: params}) do
+    case CogApi.HTTP.Internal.user_update(endpoint, user_username, %{user: params}) do
       {:ok, resp} ->
         user = resp["user"]
         username = user["username"]

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Cogctl.Mixfile do
       {:ibrowse, "~> 4.2.2"},
       {:httpotion, "~> 2.1.0"},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client", ref: "2badfd6b3d9de2c62d242b81112857a6e85bc982"},
+      {:cog_api, github: "operable/cog-api-client", ref: "3aa6f44aaf3b105c52064eebe38222fa861816aa"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "2badfd6b3d9de2c62d242b81112857a6e85bc982", [ref: "2badfd6b3d9de2c62d242b81112857a6e85bc982"]},
+%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "3aa6f44aaf3b105c52064eebe38222fa861816aa", [ref: "3aa6f44aaf3b105c52064eebe38222fa861816aa"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "getopt": {:git, "https://github.com/jcomellas/getopt.git", "388dc95caa7fb97ec7db8cfc39246a36aba61bd8", [tag: "v0.8.2"]},


### PR DESCRIPTION
These changes allow use of the CogAPI master branch. 

As the CogAPI changes this allows for an easier time of switching to the newer CogAPI calls from the `Internal` modules.

Fixes https://github.com/operable/cog/issues/488