### PR TITLE
Fix mix and relay deletion failure

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Cogctl.Mixfile do
       {:ibrowse, "~> 4.2.2"},
       {:httpotion, "~> 2.1.0"},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client", ref: "a31ba9c006fc036088334b5439580b81ad16edb3"},
+      {:cog_api, github: "operable/cog-api-client"},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "a31ba9c006fc036088334b5439580b81ad16edb3", [ref: "a31ba9c006fc036088334b5439580b81ad16edb3"]},
+%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "a31ba9c006fc036088334b5439580b81ad16edb3", []},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "getopt": {:git, "https://github.com/jcomellas/getopt.git", "388dc95caa7fb97ec7db8cfc39246a36aba61bd8", [tag: "v0.8.2"]},

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -415,7 +415,8 @@ defmodule CogctlTest do
 
     assert run("cogctl relays delete test-relay mimimi") =~ ~r"""
     Deleted test-relay
-    ERROR: Resource not found: The relay mimimi could not be deleted
+    ERROR: The relay `mimimi` could not be deleted: Resource not found
+    Error: 1
     """
 
   end


### PR DESCRIPTION
Use the master cogAPI and correct the error message in the relay deletion.