### PR TITLE
Simplify creation and assigning of relays to relay-groups

### DIFF
--- a/lib/cogctl/actions/relay_groups/create.ex
+++ b/lib/cogctl/actions/relay_groups/create.ex
@@ -1,16 +1,18 @@
 defmodule Cogctl.Actions.RelayGroups.Create do
   use Cogctl.Action, "relay-groups create"
-  import Cogctl.Actions.RelayGroups.Util, only: [render: 3]
+  import Cogctl.Actions.RelayGroups.Util, only: [render: 2, render: 3]
 
   def option_spec do
-    [{:name, :undefined, :undefined, {:string, :undefined}, 'Relay name (required)'}]
+    [{:name, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
+     {:members, :undefined, 'members', {:list, :undefined}, 'Relay names'}]
   end
 
   def run(options, _args, _config, %{token: nil}=endpoint) do
     with_authentication(endpoint, &run(options, nil, nil, &1))
   end
   def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, [name: :required]) do
+    case convert_to_params(options, option_spec, [name: :required,
+                                                  members: :optional]) do
       {:ok, params} ->
         do_create(endpoint, params)
       _ ->
@@ -24,9 +26,26 @@ defmodule Cogctl.Actions.RelayGroups.Create do
         group_attrs = Enum.map([{"ID", :id}, {"Name", :name}], fn({title, attr}) ->
             [title, Map.fetch!(group, attr)]
             end)
-        render(group_attrs, false, "Created relay group `#{group.name}`")
+        case Map.get(params, :members) do
+          nil ->
+            render(group_attrs, false)
+          relays ->
+            add_to_group(group, relays, endpoint)
+            |> render(group_attrs, false)
+        end
       {:error, error} ->
         display_error(error)
     end
+  end
+
+  defp add_to_group(group, relays, endpoint) do
+    Enum.flat_map_reduce(relays, 0, fn(relay, acc) ->
+       case CogApi.HTTP.Client.relay_group_add_relay(%{name: group.name}, %{relay: relay}, endpoint) do
+         {:ok, _} ->
+           {["Adding '#{relay}' to relay group '#{group.name}': Ok."], acc}
+         {:error, error} ->
+           {["Adding '#{relay}' to relay group '#{group.name}': Error. " <> Enum.join(error, ", ")], acc + 1}
+       end
+    end)
   end
 end

--- a/lib/cogctl/actions/relay_groups/util.ex
+++ b/lib/cogctl/actions/relay_groups/util.ex
@@ -12,8 +12,21 @@ defmodule Cogctl.Actions.RelayGroups.Util do
     Table.format(group_info, sort) |> display_output
   end
 
+  def render({relay_messages, error_count}, group_info, sort) do
+    relay_message = Enum.join(relay_messages, "\n")
+    Table.format(group_info, sort) <> "\n\n" <> relay_message
+    |> display_output
+    if error_count > 0, do: :error
+  end
   def render(group_info, sort, message) do
     message <> "\n\n" <> Table.format(group_info, sort) |> display_output
+  end
+
+  def render({relay_messages, error_count}, group_info, sort, message) do
+    relay_message = Enum.join(relay_messages, "\n")
+    message <> "\n\n" <> Table.format(group_info, sort) <> "\n\n" <> relay_message
+    |> display_output
+    if error_count > 0, do: :error
   end
 
   def render(group_info, relay_info, bundle_info, sort, nil) do

--- a/lib/cogctl/actions/relays/create.ex
+++ b/lib/cogctl/actions/relays/create.ex
@@ -1,20 +1,22 @@
 defmodule Cogctl.Actions.Relays.Create do
   use Cogctl.Action, "relays create"
-  import Cogctl.Actions.Relays.Util, only: [render: 3]
+  import Cogctl.Actions.Relays.Util, only: [render: 2, render: 3]
 
   def option_spec do
     [{:name, :undefined, :undefined, {:string, :undefined}, 'Relay name (required)'},
      {:token, :undefined, 'token', {:string, :undefined}, 'Relay token (required)'},
-     {:description, :undefined, 'description', {:string, :undefined}, 'Relay description'}]
+     {:description, :undefined, 'description', {:string, :undefined}, 'Relay description'},
+     {:groups, :undefined, 'groups', {:list, :undefined}, 'Relay groups'}]
   end
 
   def run(options, _args, _config, %{token: nil}=endpoint) do
     with_authentication(endpoint, &run(options, nil, nil, &1))
   end
   def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, [name: :required,
-                                     token: :required,
-                                     description: :optional]) do
+    case convert_to_params(options, option_spec, [name: :required,
+                                                  token: :required,
+                                                  description: :optional,
+                                                  groups: :optional]) do
       {:ok, params} ->
         do_create(endpoint, params)
       _ ->
@@ -28,9 +30,27 @@ defmodule Cogctl.Actions.Relays.Create do
         relay_attrs = Enum.map([{"ID", :id}, {"Name", :name}], fn({title, attr}) ->
             [title, Map.fetch!(relay, attr)]
             end)
-        render(relay_attrs, false, "Created #{relay.name}")
+        case Map.get(params, :groups) do
+          nil ->
+            render(relay_attrs, false)
+          relay_groups ->
+            add_to_group(relay, relay_groups, endpoint)
+            |> render(relay_attrs, false)
+        end
+
       {:error, error} ->
         display_error(error)
     end
+  end
+
+  defp add_to_group(relay, relay_groups, endpoint) do
+    Enum.flat_map_reduce(relay_groups, 0, fn(group, acc) ->
+       case CogApi.HTTP.Client.relay_group_add_relay(%{name: group}, %{relay: relay.name}, endpoint) do
+         {:ok, _} ->
+           {["Adding '#{relay.name}' to relay group '#{group}': Ok."], acc}
+         {:error, error} ->
+           {["Adding '#{relay.name}' to relay group '#{group}': Error. " <> Enum.join(error, ", ")], acc + 1}
+       end
+    end)
   end
 end

--- a/lib/cogctl/actions/relays/update.ex
+++ b/lib/cogctl/actions/relays/update.ex
@@ -5,6 +5,7 @@ defmodule Cogctl.Actions.Relays.Update do
   def option_spec do
     [{:relay, :undefined, :undefined, {:string, :undefined}, 'Current Relay name (required)'},
      {:name, :undefined, 'name', {:string, :undefined}, 'name'},
+     {:token, :undefined, 'token', {:string, :undefined}, 'token'},
      {:description, :undefined, 'description', {:string, :undefined}, 'description'}]
   end
 
@@ -14,6 +15,7 @@ defmodule Cogctl.Actions.Relays.Update do
   def run(options, _args, _config, endpoint) do
     case convert_to_params(options, [relay: :required,
                                      name: :optional,
+                                     token: :optional,
                                      description: :optional]) do
       {:ok, params} ->
         do_update(endpoint, params)

--- a/lib/cogctl/actions/relays/util.ex
+++ b/lib/cogctl/actions/relays/util.ex
@@ -17,10 +17,22 @@ defmodule Cogctl.Actions.Relays.Util do
     Table.format(relay_info, sort) |> display_output
   end
 
+  def render({relay_group_messages, error_count}, relay_info, sort) do
+    group_message = Enum.join(relay_group_messages, "\n")
+    Table.format(relay_info, sort) <> "\n\n" <> group_message
+    |> display_output
+    if error_count > 0, do: :error
+  end
   def render(relay_info, sort, message) do
     message <> "\n\n" <> Table.format(relay_info, sort) |> display_output
   end
 
+  def render({relay_group_messages, error_count}, relay_info, sort, message) do
+    group_message = Enum.join(relay_group_messages, "\n")
+    message <> "\n\n" <> Table.format(relay_info, sort) <> "\n\n" <> group_message
+    |> display_output
+    if error_count > 0, do: :error
+  end
   def render(relay_info, group_info, sort, nil) do
     Table.format(relay_info, false) <> "\n\nRelay Groups\n" <> Table.format(group_info, sort)
     |> display_output

--- a/lib/cogctl/actions/users/util.ex
+++ b/lib/cogctl/actions/users/util.ex
@@ -1,0 +1,16 @@
+defmodule Cogctl.Actions.Users.Util do
+  alias Cogctl.Table
+  import Cogctl.ActionUtil , only: [display_output: 1, display_error: 1]
+
+  def render(user_info, sort) do
+    Table.format(user_info, sort) |> display_output
+  end
+
+  def render(user_info, group_info, role_info, sort) do
+    Table.format(user_info, false)
+        <> "\n\nGroups:\n" <> Table.format(group_info, sort)
+        <> "\n\nRoles:\n" <> Table.format(role_info, sort)
+    |> display_output
+  end
+
+end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Cogctl.Mixfile do
       # We override poison here because spanner is set to 1.5.2 due to phoenix requirements
       {:poison, "~> 2.0", override: true},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client"},
+      {:cog_api, github: "operable/cog-api-client", ref: "b9a7c65c18c86dba47f22fc5de666c94aa2263c0"},
       {:spanner, github: "operable/spanner"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"adz": {:git, "https://github.com/operable/adz.git", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
   "carrier": {:git, "https://github.com/operable/carrier.git", "dd1d990a3307ddfd4145723fcb6d83aeaa7b7981", []},
-  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "1c033b09b4be9271c2da1119e81bbb6766799661", []},
+  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "b9a7c65c18c86dba47f22fc5de666c94aa2263c0", [ref: "b9a7c65c18c86dba47f22fc5de666c94aa2263c0"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "emqttc": {:git, "https://github.com/operable/emqttc.git", "dc36f593822f8e01771a7edc780441fdfb2f7b15", [tag: "cog-0.2"]},

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -422,8 +422,6 @@ defmodule CogctlTest do
     """
 
     assert run("cogctl relays create test-relay --token=hola --description='Hola, Como estas'") =~ ~r"""
-    Created test-relay
-
     ID    .*
     Name  test-relay
     """
@@ -463,8 +461,20 @@ defmodule CogctlTest do
     assert run("cogctl relays delete test-relay mimimi") =~ ~r"""
     Deleted test-relay
     ERROR: The relay `mimimi` could not be deleted: Resource not found for: 'relays'
-    Error: 1
     """
+
+    run("cogctl relay-groups create mygroup")
+
+    assert run("cogctl relays create --groups=group,mygroup test-relay --token=hola") =~ ~r"""
+    ID    .*
+    Name  test-relay
+
+    Adding 'test-relay' to relay group 'group': Error. Resource not found for: 'relay_groups'
+    Adding 'test-relay' to relay group 'mygroup': Ok.
+    """
+
+    run("cogctl relays delete test-relay")
+    run("cogctl relay-groups delete mygroup")
   end
 
   test "cogctl relay-groups" do
@@ -473,8 +483,6 @@ defmodule CogctlTest do
     """
 
     assert run("cogctl relay-groups create myrelays") =~ ~r"""
-    Created relay group `myrelays`
-
     ID    .*
     Name  myrelays
     """
@@ -528,8 +536,14 @@ defmodule CogctlTest do
     assert run("cogctl relay-groups delete myrelays") =~ ~r"""
     Deleted relay group `myrelays`
     """
+    assert run("cogctl relay-groups create testgroup --members relay1,test-relay,relay3") =~ ~r"""
+    ID    .*
+    Name  testgroup
+
+    """
 
     run("cogctl relays delete test-relay my-test")
+    run("cogctl relay-groups delete testgroup")
   end
 
   test "cogctl triggers" do


### PR DESCRIPTION
* create relay and assign relay groups at the same time
* create relay groups and assign relays at the same time

This change does not create both using the same command and errors when trying to assign a group or a relay that does not exist to a newly created group or relay.

Fixes https://github.com/operable/cog/issues/535