### PR TITLE
Support bulk un/assignments to relay-groups

### DIFF
--- a/lib/cogctl/actions/relay_groups/assign.ex
+++ b/lib/cogctl/actions/relay_groups/assign.ex
@@ -28,7 +28,7 @@ defmodule Cogctl.Actions.RelayGroups.Assign do
   end
 
   defp do_assign(endpoint, params) do
-    case CogApi.HTTP.Client.relay_group_add_bundles(%{name: params.relay_group}, %{bundles: params.bundles}, endpoint) do
+    case CogApi.HTTP.Client.relay_group_assign_bundles(%{name: params.relay_group}, %{bundles: params.bundles}, endpoint) do
       {:ok, _} ->
         display_output("Assigned '#{Enum.join(params.bundles, ", ")}' to relay group `#{params.relay_group}`")
       {:error, error} ->

--- a/lib/cogctl/actions/relay_groups/assign.ex
+++ b/lib/cogctl/actions/relay_groups/assign.ex
@@ -1,28 +1,36 @@
 defmodule Cogctl.Actions.RelayGroups.Assign do
   use Cogctl.Action, "relay-groups assign"
 
+  @moduledoc """
+  Assigns bundles to relay groups. Requires the group and at least one bundle to
+  work properly. Iterates over the list of bundles and assigns them to the relay-
+  group. If an error occurs, the operation is aborted and an error message
+  returned to the user.
+  """
+
   def option_spec() do
-    [{:name, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
-     {:bundle, :undefined, 'bundle', {:string, :undefined}, 'Bundle name (required)'}]
+    [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
+     # Technically this will just be the first bundle
+     {:bundles, :undefined, :undefined, {:string, :undefined}, 'Bundle names (required)'}]
   end
 
-  def run(options, _args, _config, %{token: nil}=endpoint) do
-    with_authentication(endpoint, &run(options, nil, nil, &1))
-  end
-  def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, [bundle: :required,
-                                     name: :required]) do
+  def run(options, args, _config, endpoint) do
+    # At least one bundle is required, so we specify that here
+    case convert_to_params(options, [relay_group: :required,
+                                     bundles: :required]) do
       {:ok, params} ->
-        do_assign(endpoint, params)
-      _ ->
+        # The rest of the bundles, if there are any, get appended here.
+        params = %{params | bundles: [params.bundles | args]}
+        with_authentication(endpoint, &do_assign(&1, params))
+      :error ->
         display_arguments_error
     end
   end
 
   defp do_assign(endpoint, params) do
-    case CogApi.HTTP.Client.relay_group_add_bundle(%{name: params.name}, %{bundle: params.bundle}, endpoint) do
+    case CogApi.HTTP.Client.relay_group_add_bundles(%{name: params.relay_group}, %{bundles: params.bundles}, endpoint) do
       {:ok, _} ->
-        display_output("Bundle `#{params.bundle}` assigned to relay group `#{params.name}`")
+        display_output("Assigned '#{Enum.join(params.bundles, ", ")}' to relay group `#{params.relay_group}`")
       {:error, error} ->
         display_error(error)
     end

--- a/lib/cogctl/actions/relay_groups/assign.ex
+++ b/lib/cogctl/actions/relay_groups/assign.ex
@@ -28,7 +28,7 @@ defmodule Cogctl.Actions.RelayGroups.Assign do
   end
 
   defp do_assign(endpoint, params) do
-    case CogApi.HTTP.Client.relay_group_assign_bundles(%{name: params.relay_group}, %{bundles: params.bundles}, endpoint) do
+    case CogApi.HTTP.Client.relay_group_add_bundles(%{name: params.relay_group}, %{bundles: params.bundles}, endpoint) do
       {:ok, _} ->
         display_output("Assigned '#{Enum.join(params.bundles, ", ")}' to relay group `#{params.relay_group}`")
       {:error, error} ->

--- a/lib/cogctl/actions/relay_groups/unassign.ex
+++ b/lib/cogctl/actions/relay_groups/unassign.ex
@@ -1,28 +1,36 @@
 defmodule Cogctl.Actions.RelayGroups.Unassign do
   use Cogctl.Action, "relay-groups unassign"
 
+  @moduledoc """
+  Unassigns bundles to relay groups. Requires the group and at least one bundle to
+  work properly. Iterates over the list of bundles and removes the assignment from
+  the relay-group. If an error occurs, the operation is aborted and an error message
+  returned to the user.
+  """
+
   def option_spec() do
-    [{:name, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
-     {:bundle, :undefined, 'bundle', {:string, :undefined}, 'Bundle name (required)'}]
+    [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
+     # Technically this will just be the first bundle
+     {:bundles, :undefined, :undefined, {:string, :undefined}, 'Bundle names (required)'}]
   end
 
-  def run(options, _args, _config, %{token: nil}=endpoint) do
-    with_authentication(endpoint, &run(options, nil, nil, &1))
-  end
-  def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, [bundle: :required,
-                                     name: :required]) do
+  def run(options, args, _config, endpoint) do
+    # At least one bundle is required, so we specify that here
+    case convert_to_params(options, [relay_group: :required,
+                                     bundles: :required]) do
       {:ok, params} ->
-        do_unassign(endpoint, params)
-      _ ->
+        # The rest of the bundles, if there are any, get appended here.
+        params = %{params | bundles: [params.bundles | args]}
+        with_authentication(endpoint, &do_unassign(&1, params))
+      :error ->
         display_arguments_error
     end
   end
 
   defp do_unassign(endpoint, params) do
-    case CogApi.HTTP.Client.relay_group_remove_bundle(%{name: params.name}, %{bundle: params.bundle}, endpoint) do
+    case CogApi.HTTP.Client.relay_group_remove_bundles(%{name: params.relay_group}, %{bundles: params.bundles}, endpoint) do
       {:ok, _} ->
-        display_output("Bundle `#{params.bundle}` unassigned from relay group `#{params.name}`")
+        display_output("Unassigned '#{Enum.join(params.bundles, ", ")}' from relay group `#{params.relay_group}`")
       {:error, error} ->
         display_error(error)
     end

--- a/lib/cogctl/actions/roles/grant.ex
+++ b/lib/cogctl/actions/roles/grant.ex
@@ -24,7 +24,7 @@ defmodule Cogctl.Actions.Roles.Grant do
   defp do_grant(_endpoint, _role, :undefined), do: display_arguments_error
 
   defp do_grant(endpoint, role, group) do
-    case HTTP.Roles.grant(endpoint, role, group) do
+    case HTTP.Client.group_add_role(endpoint, group, role) do
       {:ok, _} ->
         display_output("Granted #{role.name} to #{group.name}")
       {:error, error} ->

--- a/lib/cogctl/actions/roles/revoke.ex
+++ b/lib/cogctl/actions/roles/revoke.ex
@@ -16,13 +16,13 @@ defmodule Cogctl.Actions.Roles.Revoke do
   defp do_revoke(_endpoint, _, :undefined), do: display_arguments_error
 
   defp do_revoke(endpoint, role, group_to_revoke) do
-    group = with {:ok, groups} = CogApi.HTTP.Groups.index(endpoint), 
+    group = with {:ok, groups} = CogApi.HTTP.Client.group_index(endpoint),
       do: Enum.find(groups, fn(group) -> group.name == group_to_revoke end)
 
-    revoke_role = with {:ok, roles} = CogApi.HTTP.Roles.index(endpoint),
+    revoke_role = with {:ok, roles} = CogApi.HTTP.Client.role_index(endpoint),
       do: Enum.find(roles, fn(r) -> r.name == role end)
 
-    case CogApi.HTTP.Roles.revoke(endpoint, revoke_role, group) do
+    case CogApi.HTTP.Client.group_remove_role(endpoint, group, revoke_role) do
       {:ok, _resp} ->
         display_output("Revoked #{role} from #{group_to_revoke}")
       {:error, error} ->

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Cogctl.Mixfile do
       # We override poison here because spanner is set to 1.5.2 due to phoenix requirements
       {:poison, "~> 2.0", override: true},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client", ref: "f8853e2acd233bd53e5988fa6e6a57334cff787e"},
+      {:cog_api, github: "operable/cog-api-client", ref: "2c2dd4eb9fbe6f54a8fff64490cd86c9f7a693ea"},
       {:spanner, github: "operable/spanner"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,8 @@ defmodule Cogctl.Mixfile do
       # We override poison here because spanner is set to 1.5.2 due to phoenix requirements
       {:poison, "~> 2.0", override: true},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client"},
+      #{:cog_api, github: "operable/cog-api-client"},
+      {:cog_api, path: "../cog-api-client"},
       {:spanner, github: "operable/spanner"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -28,8 +28,7 @@ defmodule Cogctl.Mixfile do
       # We override poison here because spanner is set to 1.5.2 due to phoenix requirements
       {:poison, "~> 2.0", override: true},
       {:configparser_ex, "~> 0.2.0"},
-      #{:cog_api, github: "operable/cog-api-client"},
-      {:cog_api, path: "../cog-api-client"},
+      {:cog_api, github: "operable/cog-api-client", ref: "f8853e2acd233bd53e5988fa6e6a57334cff787e"},
       {:spanner, github: "operable/spanner"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Cogctl.Mixfile do
       # We override poison here because spanner is set to 1.5.2 due to phoenix requirements
       {:poison, "~> 2.0", override: true},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client", ref: "2c2dd4eb9fbe6f54a8fff64490cd86c9f7a693ea"},
+      {:cog_api, github: "operable/cog-api-client", ref: "1c033b09b4be9271c2da1119e81bbb6766799661"},
       {:spanner, github: "operable/spanner"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"adz": {:git, "https://github.com/operable/adz.git", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
   "carrier": {:git, "https://github.com/operable/carrier.git", "dd1d990a3307ddfd4145723fcb6d83aeaa7b7981", []},
-  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "f8853e2acd233bd53e5988fa6e6a57334cff787e", [ref: "f8853e2acd233bd53e5988fa6e6a57334cff787e"]},
+  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "2c2dd4eb9fbe6f54a8fff64490cd86c9f7a693ea", [ref: "2c2dd4eb9fbe6f54a8fff64490cd86c9f7a693ea"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "emqttc": {:git, "https://github.com/operable/emqttc.git", "dc36f593822f8e01771a7edc780441fdfb2f7b15", [tag: "cog-0.2"]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"adz": {:git, "https://github.com/operable/adz.git", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
   "carrier": {:git, "https://github.com/operable/carrier.git", "dd1d990a3307ddfd4145723fcb6d83aeaa7b7981", []},
-  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "897752b178f5b1c548ab096fdbf2e024d37d5642", []},
+  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "e96863ec36e7f8225d638fd98fbe59b8fdc39cc3", []},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "emqttc": {:git, "https://github.com/operable/emqttc.git", "dc36f593822f8e01771a7edc780441fdfb2f7b15", [tag: "cog-0.2"]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"adz": {:git, "https://github.com/operable/adz.git", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
   "carrier": {:git, "https://github.com/operable/carrier.git", "dd1d990a3307ddfd4145723fcb6d83aeaa7b7981", []},
-  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "2c2dd4eb9fbe6f54a8fff64490cd86c9f7a693ea", [ref: "2c2dd4eb9fbe6f54a8fff64490cd86c9f7a693ea"]},
+  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "6b0d3cb3eb503bc29a54e650d399b92b250ea9e3", [ref: "1c033b09b4be9271c2da1119e81bbb6766799661"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "emqttc": {:git, "https://github.com/operable/emqttc.git", "dc36f593822f8e01771a7edc780441fdfb2f7b15", [tag: "cog-0.2"]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"adz": {:git, "https://github.com/operable/adz.git", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
   "carrier": {:git, "https://github.com/operable/carrier.git", "dd1d990a3307ddfd4145723fcb6d83aeaa7b7981", []},
-  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "e96863ec36e7f8225d638fd98fbe59b8fdc39cc3", []},
+  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "f8853e2acd233bd53e5988fa6e6a57334cff787e", [ref: "f8853e2acd233bd53e5988fa6e6a57334cff787e"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "emqttc": {:git, "https://github.com/operable/emqttc.git", "dc36f593822f8e01771a7edc780441fdfb2f7b15", [tag: "cog-0.2"]},


### PR DESCRIPTION
Changes to relay-groups to allow for multiple bundle assignments.

The syntax is now:
`cogctl relay-groups assign mygroup bundle1 bundle2 bundle3`
`cogctl relay-groups unassign mygroup bundle1 bundle2 bundle3`

depends on https://github.com/operable/cog-api-client/pull/89
resolves https://github.com/operable/cog/issues/536