### PR TITLE
remove error code when deleting relays

### DIFF
--- a/lib/cogctl/action_util.ex
+++ b/lib/cogctl/action_util.ex
@@ -127,8 +127,7 @@ defmodule Cogctl.ActionUtil do
   end
 
   def display_error(errors) when is_list(errors) do 
-    "ERROR: " <> Enum.join(errors, "\n")
-    |> IO.puts
+    IO.puts(:stderr, "ERROR: " <> Enum.join(errors, "\n"))
     :error
   end
   def display_error(error) do

--- a/lib/cogctl/actions/relays/delete.ex
+++ b/lib/cogctl/actions/relays/delete.ex
@@ -21,11 +21,14 @@ defmodule Cogctl.Actions.Relays.Delete do
       end
     end)
 
-    if length(results.failure) > 0 do
-      display_error(Enum.join(results.failure, ","))
-    end
     if length(results.success) > 0 do
       display_output("Deleted '#{Enum.join(results.success, ",")}'")
+    end
+    if length(results.failure) > 0 do
+      Enum.each(results.failure, &display_error/1)
+      :error
+    else
+      :ok
     end
 
   end

--- a/lib/cogctl/actions/relays/delete.ex
+++ b/lib/cogctl/actions/relays/delete.ex
@@ -22,7 +22,7 @@ defmodule Cogctl.Actions.Relays.Delete do
     end)
 
     if length(results.failure) > 0 do
-      display_error("Error '#{Enum.join(results.failure, ",")}'")
+      display_error(Enum.join(results.failure, ","))
     end
     if length(results.success) > 0 do
       display_output("Deleted '#{Enum.join(results.success, ",")}'")

--- a/lib/cogctl/actions/relays/delete.ex
+++ b/lib/cogctl/actions/relays/delete.ex
@@ -14,20 +14,28 @@ defmodule Cogctl.Actions.Relays.Delete do
   end
 
   defp do_delete(endpoint, relay_names) do
-    Enum.reduce(relay_names, 0, fn(relay_name, acc) ->
+    results = Enum.reduce(relay_names, %{success: [], failure: []}, fn(relay_name, acc) ->
       case delete(endpoint, relay_name) do
-        :ok -> acc
-        _ -> acc + 1
+        {:ok, name} -> %{acc | success: [name | acc.success]}
+        {:error, error} -> %{acc | failure: [error | acc.failure]}
       end
     end)
+
+    if length(results.failure) > 0 do
+      display_error("Error '#{Enum.join(results.failure, ",")}'")
+    end
+    if length(results.success) > 0 do
+      display_output("Deleted '#{Enum.join(results.success, ",")}'")
+    end
+
   end
 
   defp delete(endpoint, relay_name) do
     case CogApi.HTTP.Client.relay_delete(%{name: relay_name}, endpoint) do
       :ok ->
-        display_output("Deleted #{relay_name}")
+        {:ok, relay_name}
       {:error, error} ->
-        display_error(error)
+        {:error, error}
     end
   end
 end

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -459,8 +459,8 @@ defmodule CogctlTest do
     """
 
     assert run("cogctl relays delete test-relay mimimi") =~ ~r"""
-    Deleted test-relay
-    ERROR: The relay `mimimi` could not be deleted: Resource not found for: 'relays'
+    Deleted 'test-relay'
+    ERROR: "The relay `mimimi` could not be deleted: Resource not found for: 'relays'"
     """
 
     run("cogctl relay-groups create mygroup")

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -460,7 +460,7 @@ defmodule CogctlTest do
 
     assert run("cogctl relays delete test-relay mimimi") =~ ~r"""
     Deleted 'test-relay'
-    ERROR: "The relay `mimimi` could not be deleted: Resource not found for: 'relays'"
+    ERROR: The relay `mimimi` could not be deleted: Resource not found for: 'relays'
     """
 
     run("cogctl relay-groups create mygroup")


### PR DESCRIPTION
cogctl displayed an error code after successfully deleting a relay. This should remove that.

resolves https://github.com/operable/cog/issues/541