### PR TITLE
Required args

### DIFF
--- a/lib/cogctl/action_util.ex
+++ b/lib/cogctl/action_util.ex
@@ -29,27 +29,27 @@ defmodule Cogctl.ActionUtil do
     params = Keyword.take(options, Keyword.keys(whitelist))
 
     # Check if any required params are undefined
-    invalid = Enum.any?(params, fn
-      {key, :undefined} ->
+    missing_params = Enum.filter(params, fn
+      ({key, :undefined}) ->
         case Keyword.get(whitelist, key, :optional) do
           :required ->
             true
           :optional ->
             false
         end
-      _ ->
-        false
+      (_) -> false
     end)
 
-    case invalid do
-      true ->
-        :error
-      false ->
+    case missing_params do
+      [] ->
         params = params
                   |> Enum.reject(&match?({_, :undefined}, &1))
                   |> Enum.into(%{})
 
         {:ok, params}
+      missing ->
+        missing_keys = Enum.map(missing, fn({key, _}) -> key end)
+        {:error, {:missing_params, missing_keys}}
     end
   end
 
@@ -101,9 +101,13 @@ defmodule Cogctl.ActionUtil do
     :error
   end
 
-  def display_arguments_error do
-    display_error("Missing required arguments")
-  end
+  def display_arguments_error,
+    do: display_error("Missing required arguments")
+
+  def display_arguments_error(missing_args) when is_list(missing_args),
+    do: display_error("Missing required arguments: '#{Enum.join(missing_args, ",")}'")
+  def display_arguments_error(missing_arg),
+    do: display_error("Missing required argument: '#{missing_arg}'")
 
   defp format_error(%{"errors" => errors}), do: format_error(errors)
   defp format_error(error) when is_list(error), do: Enum.join(error, "\n")

--- a/lib/cogctl/actions/bundles/create.ex
+++ b/lib/cogctl/actions/bundles/create.ex
@@ -35,8 +35,8 @@ defmodule Cogctl.Actions.Bundles.Create do
                                      templates: :required]) do
       {:ok, params} ->
         with_authentication(endpoint, &do_create(&1, params))
-      :error ->
-        display_arguments_error
+      {:error, {:missing_params, missing_params}} ->
+        display_arguments_error(missing_params)
     end
   end
 

--- a/lib/cogctl/actions/bundles/delete.ex
+++ b/lib/cogctl/actions/bundles/delete.ex
@@ -9,7 +9,7 @@ defmodule Cogctl.Actions.Bundles.Delete do
     do: with_authentication(endpoint, &do_delete(&1, args))
 
   defp do_delete(_endpoint, []) do
-    display_arguments_error
+    display_arguments_error("bundle")
   end
 
   defp do_delete(endpoint, bundle_names) when is_list(bundle_names) do

--- a/lib/cogctl/actions/chat_handles/create.ex
+++ b/lib/cogctl/actions/chat_handles/create.ex
@@ -9,15 +9,17 @@ defmodule Cogctl.Actions.ChatHandles.Create do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options, [user: :required, chat_provider: :required, handle: :required])
-    with_authentication(endpoint, &do_create(&1, params))
+    case convert_to_params(options, [user: :required,
+                                     chat_provider: :required,
+                                     handle: :required]) do
+      {:ok, params} ->
+        with_authentication(endpoint, &do_create(&1, params))
+      {:error, {:missing_params, missing_params}} ->
+        display_arguments_error(missing_params)
+    end
   end
 
-  defp do_create(_endpoint, :error) do
-    display_arguments_error
-  end
-
-  defp do_create(endpoint, {:ok, params}) do
+  defp do_create(endpoint, params) do
     case CogApi.HTTP.Internal.chat_handle_create(endpoint, %{chat_handle: params}) do
       {:ok, resp} ->
         chat_handle = resp["chat_handle"]

--- a/lib/cogctl/actions/chat_handles/delete.ex
+++ b/lib/cogctl/actions/chat_handles/delete.ex
@@ -7,15 +7,16 @@ defmodule Cogctl.Actions.ChatHandles.Delete do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options, [user: :required, chat_provider: :required])
-    with_authentication(endpoint, &do_delete(&1, params))
+    case convert_to_params(options, [user: :required,
+                                     chat_provider: :required]) do
+      {:ok, params} ->
+        with_authentication(endpoint, &do_delete(&1, params))
+      {:error, {:missing_params, missing_params}} ->
+        display_arguments_error(missing_params)
+    end
   end
 
-  defp do_delete(_endpoint, :error) do
-    display_arguments_error
-  end
-
-  defp do_delete(endpoint, {:ok, params}) do
+  defp do_delete(endpoint, params) do
     case CogApi.HTTP.Internal.chat_handle_delete(endpoint, %{chat_handle: params}) do
       :ok ->
         display_output("Deleted chat handle owned by #{params[:user]} for #{params[:chat_provider]} chat provider")

--- a/lib/cogctl/actions/permissions.ex
+++ b/lib/cogctl/actions/permissions.ex
@@ -11,8 +11,8 @@ defmodule Cogctl.Actions.Permissions do
     with_authentication(endpoint, &do_list(&1, params))
   end
 
-  defp do_list(_endpoint, :error) do
-    display_arguments_error
+  defp do_list(_endpoint, {:error, {:missing_params, missing_params}}) do
+    display_arguments_error(missing_params)
   end
 
   defp do_list(endpoint, {:ok, params}) do

--- a/lib/cogctl/actions/relay_groups/add.ex
+++ b/lib/cogctl/actions/relay_groups/add.ex
@@ -14,8 +14,8 @@ defmodule Cogctl.Actions.RelayGroups.Add do
                                      name: :required]) do
       {:ok, params} ->
         do_add(endpoint, params)
-      _ ->
-        display_arguments_error
+      {:error, {:missing_params, missing_args}} ->
+        display_arguments_error(missing_args)
     end
   end
 

--- a/lib/cogctl/actions/relay_groups/assign.ex
+++ b/lib/cogctl/actions/relay_groups/assign.ex
@@ -22,8 +22,8 @@ defmodule Cogctl.Actions.RelayGroups.Assign do
         # The rest of the bundles, if there are any, get appended here.
         params = %{params | bundles: [params.bundles | args]}
         with_authentication(endpoint, &do_assign(&1, params))
-      :error ->
-        display_arguments_error
+      {:error, {:missing_params, missing_params}} ->
+        display_arguments_error(missing_params)
     end
   end
 

--- a/lib/cogctl/actions/relay_groups/create.ex
+++ b/lib/cogctl/actions/relay_groups/create.ex
@@ -13,8 +13,8 @@ defmodule Cogctl.Actions.RelayGroups.Create do
     case convert_to_params(options, [name: :required]) do
       {:ok, params} ->
         do_create(endpoint, params)
-      _ ->
-        display_arguments_error
+      {:error, {:missing_params, missing_params}} ->
+        display_arguments_error(missing_params)
     end
   end
 

--- a/lib/cogctl/actions/relay_groups/remove.ex
+++ b/lib/cogctl/actions/relay_groups/remove.ex
@@ -14,8 +14,8 @@ defmodule Cogctl.Actions.RelayGroups.Remove do
                                      name: :required]) do
       {:ok, params} ->
         do_remove(endpoint, params)
-      _ ->
-        display_arguments_error
+      {:error, {:missing_params, missing_params}} ->
+        display_arguments_error(missing_params)
     end
   end
 

--- a/lib/cogctl/actions/relay_groups/unassign.ex
+++ b/lib/cogctl/actions/relay_groups/unassign.ex
@@ -22,8 +22,8 @@ defmodule Cogctl.Actions.RelayGroups.Unassign do
         # The rest of the bundles, if there are any, get appended here.
         params = %{params | bundles: [params.bundles | args]}
         with_authentication(endpoint, &do_unassign(&1, params))
-      :error ->
-        display_arguments_error
+      {:error, {:missing_params, missing_params}} ->
+        display_arguments_error(missing_params)
     end
   end
 

--- a/lib/cogctl/actions/relays/create.ex
+++ b/lib/cogctl/actions/relays/create.ex
@@ -17,8 +17,8 @@ defmodule Cogctl.Actions.Relays.Create do
                                      description: :optional]) do
       {:ok, params} ->
         do_create(endpoint, params)
-      _ ->
-        display_arguments_error
+      {:error, {:missing_params, missing_params}} ->
+        display_arguments_error(missing_params)
     end
   end
 

--- a/lib/cogctl/actions/relays/update.ex
+++ b/lib/cogctl/actions/relays/update.ex
@@ -17,8 +17,8 @@ defmodule Cogctl.Actions.Relays.Update do
                                      description: :optional]) do
       {:ok, params} ->
         do_update(endpoint, params)
-      _ ->
-        display_arguments_error
+      {:error, {:missing_params, missing_params}} ->
+        display_arguments_error(missing_params)
     end
   end
 

--- a/lib/cogctl/actions/roles/rename.ex
+++ b/lib/cogctl/actions/roles/rename.ex
@@ -14,11 +14,11 @@ defmodule Cogctl.Actions.Roles.Rename do
   end
 
   defp do_rename(_endpoint, :undefined, _params) do
-    display_arguments_error
+    display_arguments_error("role")
   end
 
-  defp do_rename(_endpoint, _role_name, :error) do
-    display_arguments_error
+  defp do_rename(_endpoint, _role_name, {:error, {:missing_params, missing_params}}) do
+    display_arguments_error(missing_params)
   end
 
   defp do_rename(endpoint, role_name, {:ok, params}) do

--- a/lib/cogctl/actions/triggers/create.ex
+++ b/lib/cogctl/actions/triggers/create.ex
@@ -19,8 +19,8 @@ defmodule Cogctl.Actions.Triggers.Create do
                                      description: :optional]) do
       {:ok, params} ->
         with_authentication(endpoint, &do_create(&1, params))
-      :error ->
-        display_arguments_error
+      {:error, {:missing_params, missing_params}} ->
+        display_arguments_error(missing_params)
     end
   end
 

--- a/lib/cogctl/actions/triggers/update.ex
+++ b/lib/cogctl/actions/triggers/update.ex
@@ -25,8 +25,8 @@ defmodule Cogctl.Actions.Triggers.Update do
       {name, {:ok, params}} when is_binary(name) ->
         with_authentication(endpoint,
                             &do_update(&1, name, params))
-      _ ->
-        display_arguments_error
+      {:error, {:missing_params, missing_params}} ->
+        display_arguments_error(missing_params)
     end
   end
 

--- a/lib/cogctl/actions/users/create.ex
+++ b/lib/cogctl/actions/users/create.ex
@@ -23,8 +23,8 @@ defmodule Cogctl.Actions.Users.Create do
     with_authentication(endpoint, &do_create(&1, params))
   end
 
-  defp do_create(_endpoint, :error) do
-    display_arguments_error
+  defp do_create(_endpoint, {:error, {:missing_params, missing_params}}) do
+    display_arguments_error(missing_params)
   end
 
   defp do_create(endpoint, {:ok, params}) do

--- a/lib/cogctl/actions/users/update.ex
+++ b/lib/cogctl/actions/users/update.ex
@@ -22,8 +22,8 @@ defmodule Cogctl.Actions.Users.Update do
                         &do_update(&1, :proplists.get_value(:user, options), params))
   end
 
-  defp do_update(_endpoint, _user_username, :error) do
-    display_arguments_error
+  defp do_update(_endpoint, _user_username, {:error, {:missing_params, missing_params}}) do
+    display_arguments_error(missing_params)
   end
 
   defp do_update(endpoint, user_username, {:ok, params}) do

--- a/test/cogctl/action_util_test.exs
+++ b/test/cogctl/action_util_test.exs
@@ -10,7 +10,7 @@ defmodule Cogctl.ActionUtilTest do
 
   test "converting missing required options to params" do
     params = ActionUtil.convert_to_params([a: true, b: :undefined, c: false], [b: :required, c: :optional])
-    assert params == :error
+    assert params == {:error, {:missing_params, [:b]}}
   end
 
   test "with_authentication runs function when authentication succeeds" do


### PR DESCRIPTION
When the user fails to supply the proper args they are presented with a very unhelpful "Missing required arguments" message. This updates the `display_arguments_error` and `convert_to_params` to give a more informative message.

resolves https://github.com/operable/cog/issues/542