### PR TITLE
Peck/bulk relays to relaygroups

### DIFF
--- a/lib/cogctl/actions/bundles/create.ex
+++ b/lib/cogctl/actions/bundles/create.ex
@@ -99,7 +99,7 @@ defmodule Cogctl.Actions.Bundles.Create do
     relay_groups = String.split(relay_group_names, ",")
 
     Enum.map(relay_groups, fn relay_group ->
-      result = Client.relay_group_add_bundles(%{name: relay_group}, %{bundles: [bundle.name]}, endpoint)
+      result = Client.relay_group_add_bundles_by_name(relay_group, bundle.name, endpoint)
 
       case result do
         {:ok, relay_group} ->

--- a/lib/cogctl/actions/relay_groups/add.ex
+++ b/lib/cogctl/actions/relay_groups/add.ex
@@ -33,7 +33,7 @@ defmodule Cogctl.Actions.RelayGroups.Add do
   end
 
   defp do_add(endpoint, params) do
-    case CogApi.HTTP.Client.relay_group_add_relays(%{name: params.relay_group}, %{relays: params.relays}, endpoint) do
+    case CogApi.HTTP.Client.relay_group_add_relays_by_name(params.relay_group, params.relays, endpoint) do
       {:ok, _} ->
         display_output("Added '#{Enum.join(params.relays, ", ")}' to relay group '#{params.relay_group}'")
       {:error, error} ->

--- a/lib/cogctl/actions/relay_groups/add.ex
+++ b/lib/cogctl/actions/relay_groups/add.ex
@@ -1,10 +1,23 @@
 defmodule Cogctl.Actions.RelayGroups.Add do
   use Cogctl.Action, "relay-groups add"
 
+  @moduledoc """
+  Used to add relays to relay groups.
+
+  Usage:
+  'cogctl relay-groups add $RELAYGROUP $RELAY1 $RELAY2 $RELAY3'
+  """
+
   def option_spec() do
-    [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
+    [{:relay_group, :undefined, :undefined, :string, 'Relay Group name (required)'},
      # Technically this will just be the first relay
-     {:relays, :undefined, :undefined, {:string, :undefined}, 'Relay names (required)'}]
+     # This command just uses positional options. The first argument is the name
+     # of the relay group. Anything after that is considered a relay.
+     # getopt will only assign the first item in the relay list to the relays
+     # option. But that's fine since we only require one. The rest of the relays
+     # will come in as arguments. We can stick them all together before calling
+     # the api.
+     {:relays, :undefined, :undefined, :string, 'Relay names (required)'}]
   end
 
   def run(options, args, _config, endpoint) do

--- a/lib/cogctl/actions/relay_groups/add.ex
+++ b/lib/cogctl/actions/relay_groups/add.ex
@@ -2,27 +2,27 @@ defmodule Cogctl.Actions.RelayGroups.Add do
   use Cogctl.Action, "relay-groups add"
 
   def option_spec() do
-    [{:name, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
-     {:relay, :undefined, 'relay', {:string, :undefined}, 'Relay name (required)'}]
+    [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
+     # Technically this will just be the first relay
+     {:relays, :undefined, :undefined, {:string, :undefined}, 'Relay names (required)'}]
   end
 
-  def run(options, _args, _config, %{token: nil}=endpoint) do
-    with_authentication(endpoint, &run(options, nil, nil, &1))
-  end
-  def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, [relay: :required,
-                                     name: :required]) do
+  def run(options, args, _config, endpoint) do
+    # At least one relay is required, so we specify that here
+    case convert_to_params(options, [relay_group: :required,
+                                     relays: :required]) do
       {:ok, params} ->
-        do_add(endpoint, params)
+        params = %{params | relays: [params.relays | args]}
+        with_authentication(endpoint, &do_add(&1, params))
       {:error, {:missing_params, missing_args}} ->
         display_arguments_error(missing_args)
     end
   end
 
   defp do_add(endpoint, params) do
-    case CogApi.HTTP.Client.relay_group_add_relay(%{name: params.name}, %{relay: params.relay}, endpoint) do
+    case CogApi.HTTP.Client.relay_group_add_relays(%{name: params.relay_group}, %{relays: params.relays}, endpoint) do
       {:ok, _} ->
-        display_output("Relay `#{params.relay}` added to relay group `#{params.name}`")
+        display_output("Added '#{Enum.join(params.relays, ", ")}' to relay group '#{params.relay_group}'")
       {:error, error} ->
         display_error(error)
     end

--- a/lib/cogctl/actions/relay_groups/add.ex
+++ b/lib/cogctl/actions/relay_groups/add.ex
@@ -14,7 +14,7 @@ defmodule Cogctl.Actions.RelayGroups.Add do
      # This command just uses positional options. The first argument is the name
      # of the relay group. Anything after that is considered a relay.
      # getopt will only assign the first item in the relay list to the relays
-     # option. But that's fine since we only require one. The rest of the relays
+     # option, but that's fine since we only require one. The rest of the relays
      # will come in as arguments. We can stick them all together before calling
      # the api.
      {:relays, :undefined, :undefined, :string, 'Relay names (required)'}]

--- a/lib/cogctl/actions/relay_groups/assign.ex
+++ b/lib/cogctl/actions/relay_groups/assign.ex
@@ -37,7 +37,7 @@ defmodule Cogctl.Actions.RelayGroups.Assign do
   end
 
   defp do_assign(endpoint, params) do
-    case CogApi.HTTP.Client.relay_group_add_bundles(%{name: params.relay_group}, %{bundles: params.bundles}, endpoint) do
+    case CogApi.HTTP.Client.relay_group_add_bundles_by_name(params.relay_group, params.bundles, endpoint) do
       {:ok, _} ->
         display_output("Assigned '#{Enum.join(params.bundles, ", ")}' to relay group `#{params.relay_group}`")
       {:error, error} ->

--- a/lib/cogctl/actions/relay_groups/assign.ex
+++ b/lib/cogctl/actions/relay_groups/assign.ex
@@ -6,11 +6,20 @@ defmodule Cogctl.Actions.RelayGroups.Assign do
   work properly. Iterates over the list of bundles and assigns them to the relay-
   group. If an error occurs, the operation is aborted and an error message
   returned to the user.
+
+  Usage:
+  'cogctl relay-groups assign $RELAYGROUP $BUNDLE1 $BUNDLE2 $BUNDLE3'
   """
 
   def option_spec() do
     [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
-     # Technically this will just be the first bundle
+     # Technically this will just be the first relay
+     # This command just uses positional options. The first argument is the name
+     # of the relay group. Anything after that is considered a bundle.
+     # getopt will only assign the first item in the bundle list to the bundles
+     # option, but that's fine since we only require one. The rest of the bundles
+     # will come in as arguments. We can stick them all together before calling
+     # the api.
      {:bundles, :undefined, :undefined, {:string, :undefined}, 'Bundle names (required)'}]
   end
 

--- a/lib/cogctl/actions/relay_groups/assign.ex
+++ b/lib/cogctl/actions/relay_groups/assign.ex
@@ -8,28 +8,20 @@ defmodule Cogctl.Actions.RelayGroups.Assign do
   returned to the user.
 
   Usage:
-  'cogctl relay-groups assign $RELAYGROUP $BUNDLE1 $BUNDLE2 $BUNDLE3'
+  'cogctl relay-groups assign $RELAYGROUP --bundles=$BUNDLE1,$BUNDLE2,$BUNDLE3'
   """
 
   def option_spec() do
     [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
-     # Technically this will just be the first relay
-     # This command just uses positional options. The first argument is the name
-     # of the relay group. Anything after that is considered a bundle.
-     # getopt will only assign the first item in the bundle list to the bundles
-     # option, but that's fine since we only require one. The rest of the bundles
-     # will come in as arguments. We can stick them all together before calling
-     # the api.
-     {:bundles, :undefined, :undefined, {:string, :undefined}, 'Bundle names (required)'}]
+     {:bundles, :undefined, 'bundles', {:list, :undefined}, 'Bundle names (required)'}]
   end
 
-  def run(options, args, _config, endpoint) do
+  def run(options, _args, _config, endpoint) do
     # At least one bundle is required, so we specify that here
-    case convert_to_params(options, [relay_group: :required,
-                                     bundles: :required]) do
+    case convert_to_params(options, option_spec, [relay_group: :required,
+                                                  bundles: :required]) do
       {:ok, params} ->
         # The rest of the bundles, if there are any, get appended here.
-        params = %{params | bundles: [params.bundles | args]}
         with_authentication(endpoint, &do_assign(&1, params))
       {:error, {:missing_params, missing_params}} ->
         display_arguments_error(missing_params)
@@ -37,9 +29,12 @@ defmodule Cogctl.Actions.RelayGroups.Assign do
   end
 
   defp do_assign(endpoint, params) do
+    IO.inspect params.bundles
     case CogApi.HTTP.Client.relay_group_add_bundles_by_name(params.relay_group, params.bundles, endpoint) do
       {:ok, _} ->
-        display_output("Assigned '#{Enum.join(params.bundles, ", ")}' to relay group `#{params.relay_group}`")
+        bundle_string = List.wrap(params.bundles)
+        |> Enum.join(", ")
+        display_output("Assigned '#{bundle_string}' to relay group `#{params.relay_group}`")
       {:error, error} ->
         display_error(error)
     end

--- a/lib/cogctl/actions/relay_groups/create.ex
+++ b/lib/cogctl/actions/relay_groups/create.ex
@@ -40,7 +40,7 @@ defmodule Cogctl.Actions.RelayGroups.Create do
 
   defp add_to_group(group, relays, endpoint) do
     Enum.flat_map_reduce(relays, 0, fn(relay, acc) ->
-       case CogApi.HTTP.Client.relay_group_add_relay(%{name: group.name}, %{relay: relay}, endpoint) do
+       case CogApi.HTTP.Client.relay_group_add_relays(%{name: group.name}, %{relays: [relay]}, endpoint) do
          {:ok, _} ->
            {["Adding '#{relay}' to relay group '#{group.name}': Ok."], acc}
          {:error, error} ->

--- a/lib/cogctl/actions/relay_groups/create.ex
+++ b/lib/cogctl/actions/relay_groups/create.ex
@@ -40,7 +40,7 @@ defmodule Cogctl.Actions.RelayGroups.Create do
 
   defp add_to_group(group, relays, endpoint) do
     Enum.flat_map_reduce(relays, 0, fn(relay, acc) ->
-       case CogApi.HTTP.Client.relay_group_add_relays(%{name: group.name}, %{relays: [relay]}, endpoint) do
+       case CogApi.HTTP.Client.relay_group_add_relays_by_name(group.name, relay, endpoint) do
          {:ok, _} ->
            {["Adding '#{relay}' to relay group '#{group.name}': Ok."], acc}
          {:error, error} ->

--- a/lib/cogctl/actions/relay_groups/remove.ex
+++ b/lib/cogctl/actions/relay_groups/remove.ex
@@ -1,9 +1,22 @@
 defmodule Cogctl.Actions.RelayGroups.Remove do
   use Cogctl.Action, "relay-groups remove"
 
+  @moduledoc """
+  Used to remove relays from relay groups
+
+  Usage:
+  'cogctl relay-groups remove $RELAYGROUP $RELAY1 $RELAY2 $RELAY3'
+  """
+
   def option_spec() do
     [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
-     # Technically this will just be the first bundle
+     # Technically this will just be the first relay
+     # This command just uses positional options. The first argument is the name
+     # of the relay group. Anything after that is considered a relay.
+     # getopt will only assign the first item in the relay list to the relays
+     # option, but that's fine since we only require one. The rest of the relays
+     # will come in as arguments. We can stick them all together before calling
+     # the api.
      {:relays, :undefined, :undefined, {:string, :undefined}, 'Relay names (required)'}]
   end
 

--- a/lib/cogctl/actions/relay_groups/remove.ex
+++ b/lib/cogctl/actions/relay_groups/remove.ex
@@ -32,7 +32,7 @@ defmodule Cogctl.Actions.RelayGroups.Remove do
   end
 
   defp do_remove(endpoint, params) do
-    case CogApi.HTTP.Client.relay_group_remove_relays(%{name: params.relay_group}, %{relays: params.relays}, endpoint) do
+    case CogApi.HTTP.Client.relay_group_remove_relays_by_name(params.relay_group, params.relays, endpoint) do
       {:ok, _} ->
         output = ["Removed '#{params.relays}' from relay group '#{params.relay_group}'"]
 

--- a/lib/cogctl/actions/relay_groups/remove.ex
+++ b/lib/cogctl/actions/relay_groups/remove.ex
@@ -34,7 +34,7 @@ defmodule Cogctl.Actions.RelayGroups.Remove do
   defp do_remove(endpoint, params) do
     case CogApi.HTTP.Client.relay_group_remove_relays(%{name: params.relay_group}, %{relays: params.relays}, endpoint) do
       {:ok, _} ->
-        output = ["Removed `#{params.relays}` from relay group `#{params.relay_group}`"]
+        output = ["Removed '#{params.relays}' from relay group '#{params.relay_group}'"]
 
         output = case last_relay?(endpoint, params.relay_group) do
           true ->

--- a/lib/cogctl/actions/relay_groups/remove.ex
+++ b/lib/cogctl/actions/relay_groups/remove.ex
@@ -5,26 +5,18 @@ defmodule Cogctl.Actions.RelayGroups.Remove do
   Used to remove relays from relay groups
 
   Usage:
-  'cogctl relay-groups remove $RELAYGROUP $RELAY1 $RELAY2 $RELAY3'
+  'cogctl relay-groups remove $RELAYGROUP --relays=$RELAY1,$RELAY2,$RELAY3'
   """
 
   def option_spec() do
     [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
-     # Technically this will just be the first relay
-     # This command just uses positional options. The first argument is the name
-     # of the relay group. Anything after that is considered a relay.
-     # getopt will only assign the first item in the relay list to the relays
-     # option, but that's fine since we only require one. The rest of the relays
-     # will come in as arguments. We can stick them all together before calling
-     # the api.
-     {:relays, :undefined, :undefined, {:string, :undefined}, 'Relay names (required)'}]
+     {:relays, :undefined, 'relays', {:list, :undefined}, 'Relay names (required)'}]
   end
 
-  def run(options, args, _config, endpoint) do
-    case convert_to_params(options, [relay_group: :required,
-                                     relays: :required]) do
+  def run(options, _args, _config, endpoint) do
+    case convert_to_params(options, option_spec, [relay_group: :required,
+                                                  relays: :required]) do
       {:ok, params} ->
-        params = %{params | relays: [params.relays | args]}
         with_authentication(endpoint, &do_remove(&1, params))
       {:error, {:missing_params, missing_params}} ->
         display_arguments_error(missing_params)
@@ -34,7 +26,9 @@ defmodule Cogctl.Actions.RelayGroups.Remove do
   defp do_remove(endpoint, params) do
     case CogApi.HTTP.Client.relay_group_remove_relays_by_name(params.relay_group, params.relays, endpoint) do
       {:ok, _} ->
-        output = ["Removed '#{params.relays}' from relay group '#{params.relay_group}'"]
+        relay_string = List.wrap(params.relays)
+        |> Enum.join(", ")
+        output = ["Removed '#{relay_string}' from relay group '#{params.relay_group}'"]
 
         output = case last_relay?(endpoint, params.relay_group) do
           true ->

--- a/lib/cogctl/actions/relay_groups/remove.ex
+++ b/lib/cogctl/actions/relay_groups/remove.ex
@@ -2,29 +2,28 @@ defmodule Cogctl.Actions.RelayGroups.Remove do
   use Cogctl.Action, "relay-groups remove"
 
   def option_spec() do
-    [{:name, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
-     {:relay, :undefined, 'relay', {:string, :undefined}, 'Relay name (required)'}]
+    [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
+     # Technically this will just be the first bundle
+     {:relays, :undefined, :undefined, {:string, :undefined}, 'Relay names (required)'}]
   end
 
-  def run(options, _args, _config, %{token: nil}=endpoint) do
-    with_authentication(endpoint, &run(options, nil, nil, &1))
-  end
-  def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, [relay: :required,
-                                     name: :required]) do
+  def run(options, args, _config, endpoint) do
+    case convert_to_params(options, [relay_group: :required,
+                                     relays: :required]) do
       {:ok, params} ->
-        do_remove(endpoint, params)
+        params = %{params | relays: [params.relays | args]}
+        with_authentication(endpoint, &do_remove(&1, params))
       {:error, {:missing_params, missing_params}} ->
         display_arguments_error(missing_params)
     end
   end
 
   defp do_remove(endpoint, params) do
-    case CogApi.HTTP.Client.relay_group_remove_relay(%{name: params.name}, %{relay: params.relay}, endpoint) do
+    case CogApi.HTTP.Client.relay_group_remove_relays(%{name: params.relay_group}, %{relays: params.relays}, endpoint) do
       {:ok, _} ->
-        output = ["Relay `#{params.relay}` removed from relay group `#{params.name}`"]
+        output = ["Removed `#{params.relays}` from relay group `#{params.relay_group}`"]
 
-        output = case last_relay?(endpoint, params.name) do
+        output = case last_relay?(endpoint, params.relay_group) do
           true ->
             output ++ ["NOTE: There are no more relays in this group."]
           false ->
@@ -32,6 +31,7 @@ defmodule Cogctl.Actions.RelayGroups.Remove do
         end
 
         display_output(Enum.join(output, "\n\n"))
+
       {:error, error} ->
         display_error(error)
     end

--- a/lib/cogctl/actions/relay_groups/unassign.ex
+++ b/lib/cogctl/actions/relay_groups/unassign.ex
@@ -37,7 +37,7 @@ defmodule Cogctl.Actions.RelayGroups.Unassign do
   end
 
   defp do_unassign(endpoint, params) do
-    case CogApi.HTTP.Client.relay_group_remove_bundles(%{name: params.relay_group}, %{bundles: params.bundles}, endpoint) do
+    case CogApi.HTTP.Client.relay_group_remove_bundles_by_name(params.relay_group, params.bundles, endpoint) do
       {:ok, _} ->
         display_output("Unassigned '#{Enum.join(params.bundles, ", ")}' from relay group `#{params.relay_group}`")
       {:error, error} ->

--- a/lib/cogctl/actions/relay_groups/unassign.ex
+++ b/lib/cogctl/actions/relay_groups/unassign.ex
@@ -6,11 +6,20 @@ defmodule Cogctl.Actions.RelayGroups.Unassign do
   work properly. Iterates over the list of bundles and removes the assignment from
   the relay-group. If an error occurs, the operation is aborted and an error message
   returned to the user.
+
+  Usage:
+  'cogctl relay-groups unassign $RELAYGROUP $BUNDLE1 $BUNDLE2 $BUNDLE3'
   """
 
   def option_spec() do
     [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
-     # Technically this will just be the first bundle
+     # Technically this will just be the first relay
+     # This command just uses positional options. The first argument is the name
+     # of the relay group. Anything after that is considered a bundle.
+     # getopt will only assign the first item in the bundle list to the bundles
+     # option, but that's fine since we only require one. The rest of the bundles
+     # will come in as arguments. We can stick them all together before calling
+     # the api.
      {:bundles, :undefined, :undefined, {:string, :undefined}, 'Bundle names (required)'}]
   end
 

--- a/lib/cogctl/actions/relays/create.ex
+++ b/lib/cogctl/actions/relays/create.ex
@@ -45,7 +45,7 @@ defmodule Cogctl.Actions.Relays.Create do
 
   defp add_to_group(relay, relay_groups, endpoint) do
     Enum.flat_map_reduce(relay_groups, 0, fn(group, acc) ->
-       case CogApi.HTTP.Client.relay_group_add_relay(%{name: group}, %{relay: relay.name}, endpoint) do
+       case CogApi.HTTP.Client.relay_group_add_relays(%{name: group}, %{relays: [relay.name]}, endpoint) do
          {:ok, _} ->
            {["Adding '#{relay.name}' to relay group '#{group}': Ok."], acc}
          {:error, error} ->

--- a/lib/cogctl/actions/relays/create.ex
+++ b/lib/cogctl/actions/relays/create.ex
@@ -45,7 +45,7 @@ defmodule Cogctl.Actions.Relays.Create do
 
   defp add_to_group(relay, relay_groups, endpoint) do
     Enum.flat_map_reduce(relay_groups, 0, fn(group, acc) ->
-       case CogApi.HTTP.Client.relay_group_add_relays(%{name: group}, %{relays: [relay.name]}, endpoint) do
+       case CogApi.HTTP.Client.relay_group_add_relays_by_name(group, relay.name, endpoint) do
          {:ok, _} ->
            {["Adding '#{relay.name}' to relay group '#{group}': Ok."], acc}
          {:error, error} ->

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Cogctl.Mixfile do
       # We override poison here because spanner is set to 1.5.2 due to phoenix requirements
       {:poison, "~> 2.0", override: true},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client", ref: "087c64d8bbf5c9f72d5e4e078724ffe00266f9d7"},
+      {:cog_api, github: "operable/cog-api-client", ref: "f9d2c35e324663effa6c024c5e22fcdaf8906fda"},
       {:spanner, github: "operable/spanner"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Cogctl.Mixfile do
       # We override poison here because spanner is set to 1.5.2 due to phoenix requirements
       {:poison, "~> 2.0", override: true},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client"},
+      {:cog_api, github: "operable/cog-api-client", ref: "087c64d8bbf5c9f72d5e4e078724ffe00266f9d7"},
       {:spanner, github: "operable/spanner"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Cogctl.Mixfile do
       # We override poison here because spanner is set to 1.5.2 due to phoenix requirements
       {:poison, "~> 2.0", override: true},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client", ref: "f9d2c35e324663effa6c024c5e22fcdaf8906fda"},
+      {:cog_api, github: "operable/cog-api-client", branch: "lhaskins/error-handling-relay-groups"},
       {:spanner, github: "operable/spanner"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"adz": {:git, "https://github.com/operable/adz.git", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
   "carrier": {:git, "https://github.com/operable/carrier.git", "dd1d990a3307ddfd4145723fcb6d83aeaa7b7981", []},
-  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "f9d2c35e324663effa6c024c5e22fcdaf8906fda", [ref: "f9d2c35e324663effa6c024c5e22fcdaf8906fda"]},
+  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "e1d2d7d99826ec89fcdc3faf2b2f7a6653babf32", [branch: "lhaskins/error-handling-relay-groups"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "emqttc": {:git, "https://github.com/operable/emqttc.git", "dc36f593822f8e01771a7edc780441fdfb2f7b15", [tag: "cog-0.2"]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"adz": {:git, "https://github.com/operable/adz.git", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
   "carrier": {:git, "https://github.com/operable/carrier.git", "dd1d990a3307ddfd4145723fcb6d83aeaa7b7981", []},
-  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "5ede71ebf6d6ba2cdb12c30075870c76a85a9698", [ref: "087c64d8bbf5c9f72d5e4e078724ffe00266f9d7"]},
+  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "f9d2c35e324663effa6c024c5e22fcdaf8906fda", [ref: "f9d2c35e324663effa6c024c5e22fcdaf8906fda"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "emqttc": {:git, "https://github.com/operable/emqttc.git", "dc36f593822f8e01771a7edc780441fdfb2f7b15", [tag: "cog-0.2"]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"adz": {:git, "https://github.com/operable/adz.git", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
   "carrier": {:git, "https://github.com/operable/carrier.git", "dd1d990a3307ddfd4145723fcb6d83aeaa7b7981", []},
-  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "e1d2d7d99826ec89fcdc3faf2b2f7a6653babf32", [branch: "lhaskins/error-handling-relay-groups"]},
+  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "21e77a14b560c00cd7b5bea920da945bd5b4116e", [branch: "lhaskins/error-handling-relay-groups"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "emqttc": {:git, "https://github.com/operable/emqttc.git", "dc36f593822f8e01771a7edc780441fdfb2f7b15", [tag: "cog-0.2"]},

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
 %{"adz": {:git, "https://github.com/operable/adz.git", "601ceb3a19716ea635a7cd83c05f5593f5cf6c40", [tag: "0.2"]},
   "carrier": {:git, "https://github.com/operable/carrier.git", "dd1d990a3307ddfd4145723fcb6d83aeaa7b7981", []},
-  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "486018c8f473500e98f6ee3989db7a993a8ed1bc", []},
+  "cog_api": {:git, "https://github.com/operable/cog-api-client.git", "5ede71ebf6d6ba2cdb12c30075870c76a85a9698", [ref: "087c64d8bbf5c9f72d5e4e078724ffe00266f9d7"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "emqttc": {:git, "https://github.com/operable/emqttc.git", "dc36f593822f8e01771a7edc780441fdfb2f7b15", [tag: "cog-0.2"]},

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -524,6 +524,7 @@ defmodule CogctlTest do
 
     assert run("cogctl relay-groups remove myrelays my-test ") =~ ~r"""
     Removed 'my-test' from relay group 'myrelays'
+
     NOTE: There are no more relays in this group.
     """
 

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -499,7 +499,7 @@ defmodule CogctlTest do
     run("cogctl relays create test-relay --token=hola")
     run("cogctl relays create my-test --token=hola")
 
-    assert run("cogctl relay-groups add --relay=test-relay myrelays") =~ ~r"""
+    assert run("cogctl relay-groups add myrelays test-relay ") =~ ~r"""
     Relay `test-relay` added to relay group `myrelays`
     """
 
@@ -516,13 +516,13 @@ defmodule CogctlTest do
     NAME  ID
     """
 
-    run("cogctl relay-groups add --relay=my-test myrelays")
+    run("cogctl relay-groups add myrelays my-test ")
 
-    assert run("cogctl relay-groups remove --relay=test-relay myrelays") =~ ~r"""
+    assert run("cogctl relay-groups remove myrelays test-relay ") =~ ~r"""
     Relay `test-relay` removed from relay group `myrelays`
     """
 
-    assert run("cogctl relay-groups remove --relay=my-test myrelays") =~ ~r"""
+    assert run("cogctl relay-groups remove myrelays my-test ") =~ ~r"""
     Relay `my-test` removed from relay group `myrelays`
 
     NOTE: There are no more relays in this group.

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -499,7 +499,7 @@ defmodule CogctlTest do
     run("cogctl relays create test-relay --token=hola")
     run("cogctl relays create my-test --token=hola")
 
-    assert run("cogctl relay-groups add myrelays test-relay ") =~ ~r"""
+    assert run("cogctl relay-groups add myrelays --relays=test-relay") =~ ~r"""
     Added 'test-relay' to relay group 'myrelays'
     """
 
@@ -518,34 +518,34 @@ defmodule CogctlTest do
 
     run("cogctl relay-groups add myrelays my-test ")
 
-    assert run("cogctl relay-groups remove myrelays test-relay ") =~ ~r"""
+    assert run("cogctl relay-groups remove myrelays --relays=test-relay ") =~ ~r"""
     Removed 'test-relay' from relay group 'myrelays'
     """
 
-    assert run("cogctl relay-groups remove myrelays my-test ") =~ ~r"""
+    assert run("cogctl relay-groups remove myrelays --relays=my-test ") =~ ~r"""
     Removed 'my-test' from relay group 'myrelays'
 
     NOTE: There are no more relays in this group.
     """
 
-    bundle_names = ["bundle1", "bundle2"]
-    Enum.each(bundle_names, fn name ->
+    bundle_names = Enum.map(1..3, &"bundle#{&1}")
+    Enum.each(bundle_names, fn(name) ->
       pre_bundle_create(name)
       run("cogctl bundles create --templates #{@template_dir} #{Path.join(@scratch_dir, "#{name}.yaml")}")
     end)
 
-    pre_bundle_create("bundle3")
-    run("cogctl bundles create --enable --relay-groups=myrelays #{Path.join(@scratch_dir, "bundle3.yaml")}")
+    pre_bundle_create("bundle4")
+    run("cogctl bundles create --enable --relay-groups=myrelays #{Path.join(@scratch_dir, "bundle4.yaml")}")
 
-    assert run("cogctl bundles info bundle3") =~ ~r"""
+    assert run("cogctl bundles info bundle4") =~ ~r"""
     ID         .*
-    Name       bundle3
+    Name       bundle4
     Status     enabled
     Installed  .*
     """
 
-    assert run("cogctl relay-groups assign myrelays #{Enum.join(bundle_names, " ")}") =~ ~r"""
-    Assigned 'bundle1, bundle2' to relay group `myrelays`
+    assert run("cogctl relay-groups assign myrelays --bundles=#{Enum.join(bundle_names, ",")}") =~ ~r"""
+    Assigned 'bundle1, bundle2, bundle3' to relay group `myrelays`
     """
 
     assert run("cogctl relay-groups info myrelays") =~ ~r"""
@@ -561,11 +561,12 @@ defmodule CogctlTest do
     bundle1  .*
     bundle2  .*
     bundle3  .*
+    bundle4  .*
     """
 
     # Cleanup the bundle bits when we are finished
     Enum.each(bundle_names, &run("cogctl bundles delete #{&1}"))
-    run("cogctl bundles delete bundle3")
+    run("cogctl bundles delete bundle4")
     cleanup
 
     assert run("cogctl relay-groups delete myrelays") =~ ~r"""

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -524,7 +524,7 @@ defmodule CogctlTest do
 
     assert run("cogctl relay-groups remove myrelays my-test ") =~ ~r"""
     Removed 'my-test' from relay group 'myrelays'
-    \tNOTE: There are no more relays in this group.
+    NOTE: There are no more relays in this group.
     """
 
     bundle_names = ["bundle1", "bundle2"]

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -500,7 +500,7 @@ defmodule CogctlTest do
     run("cogctl relays create my-test --token=hola")
 
     assert run("cogctl relay-groups add myrelays test-relay ") =~ ~r"""
-    Relay `test-relay` added to relay group `myrelays`
+    Added 'test-relay' to relay group 'myrelays'
     """
 
     assert run("cogctl relay-groups info myrelays") =~ ~r"""
@@ -519,13 +519,12 @@ defmodule CogctlTest do
     run("cogctl relay-groups add myrelays my-test ")
 
     assert run("cogctl relay-groups remove myrelays test-relay ") =~ ~r"""
-    Relay `test-relay` removed from relay group `myrelays`
+    Removed 'test-relay' from relay group 'myrelays'
     """
 
     assert run("cogctl relay-groups remove myrelays my-test ") =~ ~r"""
-    Relay `my-test` removed from relay group `myrelays`
-
-    NOTE: There are no more relays in this group.
+    Removed 'my-test' from relay group 'myrelays'
+    \tNOTE: There are no more relays in this group.
     """
 
     bundle_names = ["bundle1", "bundle2"]


### PR DESCRIPTION
This makes adding and removing relays to relay groups use the same pattern as adding and removing bundles.

depends on https://github.com/operable/cog-api-client/pull/88