### PR TITLE
Restrict permissions on generated ~/.cogctl file

### DIFF
--- a/lib/cogctl/config.ex
+++ b/lib/cogctl/config.ex
@@ -26,6 +26,7 @@ defmodule Cogctl.Config do
         case write_values(fd, values, creating) do
           :ok ->
             File.rename(config_file(:write), config_file)
+            File.chmod(config_file, 0o600)
           error ->
             error
         end


### PR DESCRIPTION
This file will contain the password for the Cog admin user, so it should
be protected.