### PR TITLE
Return :ok instead of nil when there are no errors

### DIFF
--- a/lib/cogctl/actions/relay_groups/util.ex
+++ b/lib/cogctl/actions/relay_groups/util.ex
@@ -12,27 +12,45 @@ defmodule Cogctl.Actions.RelayGroups.Util do
     Table.format(group_info, sort) |> display_output
   end
 
-  def render({relay_messages, error_count}, group_info, sort) do
-    relay_message = Enum.join(relay_messages, "\n")
-    Table.format(group_info, sort) <> "\n\n" <> relay_message
-    |> display_output
-    if error_count > 0, do: :error
+  # If the errorcount is not equal to 0, be sure that an error code
+  # is returned upon execution
+  def render({relay_messages, 0}, group_info, sort) do
+    render_output(relay_messages, group_info, sort)
+  end
+  def render({relay_messages, _errorcount}, group_info, sort) do
+    render_output(relay_messages, group_info, sort)
+    :error
   end
   def render(group_info, sort, message) do
     message <> "\n\n" <> Table.format(group_info, sort) |> display_output
   end
 
-  def render({relay_messages, error_count}, group_info, sort, message) do
-    relay_message = Enum.join(relay_messages, "\n")
-    message <> "\n\n" <> Table.format(group_info, sort) <> "\n\n" <> relay_message
-    |> display_output
-    if error_count > 0, do: :error
+  # If the errorcount is not equal to 0, be sure that an error code
+  # is returned upon execution
+  def render({relay_messages, 0}, group_info, sort, message) do
+    render_output(relay_messages, group_info, sort, message)
+  end
+  def render({relay_messages, _errorcount}, group_info, sort, message) do
+    render_output(relay_messages, group_info, sort, message)
+    :error
   end
 
   def render(group_info, relay_info, bundle_info, sort, nil) do
     Table.format(group_info, false)
         <> "\n\nRelays\n" <> Table.format(relay_info, sort)
         <> "\n\nBundles\n" <> Table.format(bundle_info, sort)
+    |> display_output
+  end
+
+  defp render_output(relay_messages, group_info, sort) do
+    relay_message = Enum.join(relay_messages, "\n")
+    Table.format(group_info, sort) <> "\n\n" <> relay_message
+    |> display_output
+  end
+
+  defp render_output(relay_messages, group_info, sort, message) do
+    relay_message = Enum.join(relay_messages, "\n")
+    message <> relay_message <> "\n\n" <> Table.format(group_info, sort)
     |> display_output
   end
 end

--- a/lib/cogctl/actions/relays/util.ex
+++ b/lib/cogctl/actions/relays/util.ex
@@ -17,21 +17,27 @@ defmodule Cogctl.Actions.Relays.Util do
     Table.format(relay_info, sort) |> display_output
   end
 
-  def render({relay_group_messages, error_count}, relay_info, sort) do
-    group_message = Enum.join(relay_group_messages, "\n")
-    Table.format(relay_info, sort) <> "\n\n" <> group_message
-    |> display_output
-    if error_count > 0, do: :error
+  # If the errorcount is not equal to 0, be sure that an error code
+  # is returned upon execution
+  def render({relay_group_messages, 0}, relay_info, sort) do
+    render_output(relay_group_messages, relay_info, sort)
+  end
+  def render({relay_group_messages, _errorcount}, relay_info, sort) do
+    render_output(relay_group_messages, relay_info, sort)
+    :error
   end
   def render(relay_info, sort, message) do
     message <> "\n\n" <> Table.format(relay_info, sort) |> display_output
   end
 
-  def render({relay_group_messages, error_count}, relay_info, sort, message) do
-    group_message = Enum.join(relay_group_messages, "\n")
-    message <> "\n\n" <> Table.format(relay_info, sort) <> "\n\n" <> group_message
-    |> display_output
-    if error_count > 0, do: :error
+  # If the errorcount is not equal to 0, be sure that an error code
+  # is returned upon execution
+  def render({relay_group_messages, 0}, relay_info, sort, message) do
+    render_output(relay_group_messages, relay_info, sort, message)
+  end
+  def render({relay_group_messages, _errorcount}, relay_info, sort, message) do
+    render_output(relay_group_messages, relay_info, sort, message)
+    :error
   end
   def render(relay_info, group_info, sort, nil) do
     Table.format(relay_info, false) <> "\n\nRelay Groups\n" <> Table.format(group_info, sort)
@@ -53,5 +59,16 @@ defmodule Cogctl.Actions.Relays.Util do
         display_error(error)
     end
   end
-    
+
+  defp render_output(relay_group_messages, relay_info, sort) do
+    group_message = Enum.join(relay_group_messages, "\n")
+    Table.format(relay_info, sort) <> "\n\n" <> group_message
+    |> display_output
+  end
+
+  defp render_output(relay_group_messages, relay_info, sort, message) do
+    group_message = Enum.join(relay_group_messages, "\n")
+    message <> group_message <> "\n\n" <> Table.format(relay_info, sort)
+    |> display_output
+  end
 end


### PR DESCRIPTION
Currently the relay-group create (and relay create) return nil upon a successful creation and :error when something goes wrong. The function should return :ok when things are successful instead.

Connected to  https://github.com/operable/cog/issues/567