### PR TITLE
Remove the 'Created' line and display relevant information

### DIFF
--- a/lib/cogctl/actions/bundles/create.ex
+++ b/lib/cogctl/actions/bundles/create.ex
@@ -53,8 +53,7 @@ defmodule Cogctl.Actions.Bundles.Create do
 
     case result do
       {:ok, bundle} ->
-        messages = ["Created #{bundle.name} bundle"]
-        messages = messages ++ assign_to_relay_groups(endpoint, bundle, params)
+        messages = assign_to_relay_groups(endpoint, bundle, params)
 
         status = Bundles.enabled_to_status(bundle.enabled)
         bundle = Map.merge(bundle, %{status: status})

--- a/lib/cogctl/actions/chat_handles/create.ex
+++ b/lib/cogctl/actions/chat_handles/create.ex
@@ -32,11 +32,7 @@ defmodule Cogctl.Actions.ChatHandles.Create do
           [title, chat_handle[attr]]
         end
 
-        display_output("""
-        Created #{chat_handle["handle"]} for #{chat_provider} chat provider
-
-        #{Table.format(chat_handle_attrs, false)}
-        """ |> String.rstrip)
+        Table.format(chat_handle_attrs, false) |> display_output
       {:error, error} ->
         display_error(error["errors"])
     end

--- a/lib/cogctl/actions/groups/create.ex
+++ b/lib/cogctl/actions/groups/create.ex
@@ -20,7 +20,7 @@ defmodule Cogctl.Actions.Groups.Create do
   defp do_create(endpoint, group_name) do
     case Client.group_create(endpoint, %{name: group_name}) do
       {:ok, group} ->
-        Groups.render(group, "Created group #{group_name}")
+        Groups.render(group)
       {:error, message} ->
         display_error(message)
     end

--- a/lib/cogctl/actions/permissions/create.ex
+++ b/lib/cogctl/actions/permissions/create.ex
@@ -1,6 +1,8 @@
 defmodule Cogctl.Actions.Permissions.Create do
   use Cogctl.Action, "permissions create"
 
+  alias Cogctl.Actions.Permissions.View, as: PermissionView
+
   def option_spec do
     [{:name, :undefined, :undefined, {:string, :undefined}, 'Permission name (required)'}]
   end
@@ -15,11 +17,11 @@ defmodule Cogctl.Actions.Permissions.Create do
   end
 
   defp do_create(endpoint, "site:" <> name) do
-    case CogApi.HTTP.Permissions.create(endpoint, name) do
-      {:ok, _resp} ->
-        display_output("Created site:#{name}")
+    case CogApi.HTTP.Client.permission_create(endpoint, name) do
+      {:ok, permission} ->
+        PermissionView.render(permission)
       {:error, error} ->
-        display_error(error["errors"])
+        display_error(error)
     end
   end
 

--- a/lib/cogctl/actions/permissions/view.ex
+++ b/lib/cogctl/actions/permissions/view.ex
@@ -1,0 +1,19 @@
+defmodule Cogctl.Actions.Permissions.View do
+  alias Cogctl.Table
+  import Cogctl.ActionUtil , only: [display_output: 1]
+
+  def render(permission) do
+    format_table(permission)
+    |> Table.format(false)
+    |> display_output
+  end
+
+  defp format_table(permission) do
+    [
+      ["ID",    permission.id],
+      ["Namespace", permission.namespace],
+      ["Name",  permission.name],
+    ]
+  end
+
+end

--- a/lib/cogctl/actions/roles/create.ex
+++ b/lib/cogctl/actions/roles/create.ex
@@ -18,17 +18,11 @@ defmodule Cogctl.Actions.Roles.Create do
   defp do_create(endpoint, name) do
     case CogApi.HTTP.Roles.create(endpoint, %{name: name}) do
       {:ok, role} ->
-        name = role.name
-
         role_attrs = for {title, attr} <- [{"ID", :id}, {"Name", :name}] do
           [title, Map.fetch!(role, attr)]
         end
 
-        display_output("""
-        Created #{name}
-
-        #{Table.format(role_attrs, false)}
-        """ |> String.rstrip)
+        Table.format(role_attrs, false) |> display_output
       {:error, error} ->
         display_error(error)
     end

--- a/lib/cogctl/actions/rules/create.ex
+++ b/lib/cogctl/actions/rules/create.ex
@@ -21,11 +21,7 @@ defmodule Cogctl.Actions.Rules.Create do
         rule = resp["rule"]
         rule_attrs = [{"ID", resp["id"]}, {"Rule Text", rule}]
 
-        display_output("""
-        Created #{resp["id"]}
-
-        #{Table.format(rule_attrs, false)}
-        """ |> String.rstrip)
+        Table.format(rule_attrs, false) |> display_output
       {:error, error} ->
         display_error(error["errors"])
     end

--- a/lib/cogctl/actions/triggers/create.ex
+++ b/lib/cogctl/actions/triggers/create.ex
@@ -31,11 +31,7 @@ defmodule Cogctl.Actions.Triggers.Create do
       {:ok, trigger} ->
         table_data = Util.table(trigger)
 
-        display_output("""
-        Created #{trigger.name}
-
-        #{Table.format(table_data, false)}
-        """ |> String.rstrip)
+        Table.format(table_data, false) |> display_output
       {:error, error} ->
         display_error(error)
     end

--- a/lib/cogctl/actions/users/create.ex
+++ b/lib/cogctl/actions/users/create.ex
@@ -36,11 +36,7 @@ defmodule Cogctl.Actions.Users.Create do
           generate_table_row(title, Map.fetch!(user, attr))
         end
 
-        display_output("""
-        Created #{username}
-
-        #{Table.format(user_attrs, false)}
-        """ |> String.rstrip)
+        Table.format(user_attrs, false) |> display_output
       {:error, error} ->
         display_error(error)
     end

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -50,8 +50,6 @@ defmodule CogctlTest do
     pre_bundle_create("testfoo")
 
     assert run("cogctl bundles create --templates #{@template_dir} #{Path.join(@scratch_dir, "testfoo.yaml")}") =~ ~r"""
-    Created testfoo bundle
-
     ID         .*
     Name       testfoo
     Status     disabled
@@ -172,8 +170,6 @@ defmodule CogctlTest do
     """)
 
     assert output =~ ~r"""
-    Created jfrost
-
     ID          .*
     Username    jfrost
     First Name  Jack
@@ -202,8 +198,6 @@ defmodule CogctlTest do
     """)
 
     assert output =~ ~r"""
-    Created rrobin
-
     ID          .*
     Username    rrobin
     First Name
@@ -222,8 +216,6 @@ defmodule CogctlTest do
 
   test "cogctl groups" do
     assert run("cogctl groups create admin") =~ ~r"""
-    Created group admin
-
     ID     .*
     Name   admin
     Users
@@ -231,8 +223,6 @@ defmodule CogctlTest do
     """
 
     assert run("cogctl groups create ops") =~ ~r"""
-    Created group ops
-
     ID     .*
     Name   ops
     Users
@@ -264,8 +254,6 @@ defmodule CogctlTest do
     """
 
     assert run("cogctl roles create tester") =~ ~r"""
-    Created tester
-
     ID    .*
     Name  tester
     """
@@ -309,8 +297,6 @@ defmodule CogctlTest do
 
   test "cogctl roles" do
     assert run("cogctl roles create developer") =~ ~r"""
-    Created developer
-
     ID    .*
     Name  developer
     """
@@ -329,8 +315,6 @@ defmodule CogctlTest do
     """
 
     assert run("cogctl groups create helpdesk") =~ ~r"""
-    Created group helpdesk
-
     ID     .*
     Name   helpdesk
     Users
@@ -368,12 +352,12 @@ defmodule CogctlTest do
     """
 
     assert run("cogctl permissions create site:echo") =~ ~r"""
-    Created site:echo
+    ID         .*
+    Namespace  site
+    Name       echo
     """
 
     assert run("cogctl roles create developer") =~ ~r"""
-    Created developer
-
     ID    .*
     Name  developer
     """
@@ -447,8 +431,6 @@ defmodule CogctlTest do
     run("cogctl permissions create site:test")
 
     assert run("cogctl rules create --rule-text='when command is operable:echo must have site:test'") =~ ~r"""
-    Created .*
-
     ID         .*
     Rule Text  when command is operable:echo must have site:test
     """
@@ -471,7 +453,10 @@ defmodule CogctlTest do
 
   test "cogctl chat-handles" do
     assert run("cogctl chat-handles create --user=admin --chat-provider=null --handle=admininator") =~ ~r"""
-    Created admininator for null chat provider
+    ID             .*
+    User           admin
+    Chat Provider  null
+    Handle         admininator
     """
 
     assert run("cogctl chat-handles") =~ ~r"""
@@ -660,8 +645,6 @@ defmodule CogctlTest do
     """
 
     assert run("cogctl triggers create --name=echo_stuff --pipeline=echo_stuff --as-user=somebody --timeout-sec=60 --description=echo_some_stuff") =~ ~r"""
-    Created echo_stuff
-
     ID              .*
     Name            echo_stuff
     Pipeline        echo_stuff


### PR DESCRIPTION
The lines that state "Created <resource>" lines have been removed. In a couple of cases (chat-handles and permissions), the relevant data has been added. All other just displayed the relevant data that was already being displayed.

For permissions, since the relevant information wasn't being displayed, the addition of a View is being used for rendering purposes.

Connected to https://github.com/operable/cog/issues/546