### PR TITLE
Add an enable flag to the relay create action

### DIFF
--- a/lib/cogctl/actions/relays/create.ex
+++ b/lib/cogctl/actions/relays/create.ex
@@ -1,10 +1,11 @@
 defmodule Cogctl.Actions.Relays.Create do
   use Cogctl.Action, "relays create"
-  import Cogctl.Actions.Relays.Util, only: [render: 2, render: 3]
+  alias Cogctl.Actions.Relays.Util
 
   def option_spec do
     [{:name, :undefined, :undefined, {:string, :undefined}, 'Relay name (required)'},
      {:token, :undefined, 'token', {:string, :undefined}, 'Relay token (required)'},
+     {:enable, :undefined, 'enable', {:boolean, false}, 'Flag to enable the relay (default false)'},
      {:description, :undefined, 'description', {:string, :undefined}, 'Relay description'},
      {:groups, :undefined, 'groups', {:list, :undefined}, 'Relay groups'},
      {:id, :undefined, 'id', {:string, :undefined}, 'Relay id (must be uuid)'}]
@@ -16,6 +17,7 @@ defmodule Cogctl.Actions.Relays.Create do
   def run(options, _args, _config, endpoint) do
     case convert_to_params(options, option_spec, [name: :required,
                                                   token: :required,
+                                                  enable: :optional,
                                                   description: :optional,
                                                   groups: :optional,
                                                   id: :optional]) do
@@ -27,26 +29,34 @@ defmodule Cogctl.Actions.Relays.Create do
   end
 
   defp do_create(endpoint, params) do
+    with {:ok, relay} <- create_relay(endpoint, params),
+         {:ok, updated} <- enable_relay(endpoint, relay, params.enable),
+         {_, group_msgs} <- add_to_group(updated, Map.get(params, :groups, []), endpoint),
+         do: Util.render(updated, group_msgs)
+  end
+
+  defp create_relay(endpoint, params) do
     case CogApi.HTTP.Client.relay_create(params, endpoint) do
       {:ok, relay} ->
-        relay_attrs = Enum.map([{"ID", :id}, {"Name", :name}], fn({title, attr}) ->
-            [title, Map.fetch!(relay, attr)]
-            end)
-        case Map.get(params, :groups) do
-          nil ->
-            render(relay_attrs, false)
-          relay_groups ->
-            add_to_group(relay, relay_groups, endpoint)
-            |> render(relay_attrs, false)
-        end
-
+        {:ok, relay}
       {:error, error} ->
         display_error(error)
     end
   end
 
+  defp enable_relay(_endpoint, relay, false), do: {:ok, relay}
+  defp enable_relay(endpoint, relay, true) do
+    case CogApi.HTTP.Client.relay_update(%{name: relay.name}, %{enabled: true}, endpoint) do
+      {:ok, updated} ->
+        {:ok, updated}
+      {:error, error} ->
+        display_error(error)
+    end
+  end
+
+  defp add_to_group(_relay, [], _endpoint), do: {:ok, {[], 0}}
   defp add_to_group(relay, relay_groups, endpoint) do
-    Enum.flat_map_reduce(relay_groups, 0, fn(group, acc) ->
+    {msgs, errorcount} = Enum.map_reduce(relay_groups, 0, fn(group, acc) ->
        case CogApi.HTTP.Client.relay_group_add_relays_by_name(group, relay.name, endpoint) do
          {:ok, _} ->
            {["Adding '#{relay.name}' to relay group '#{group}': Ok."], acc}
@@ -54,5 +64,10 @@ defmodule Cogctl.Actions.Relays.Create do
            {["Adding '#{relay.name}' to relay group '#{group}': Error. " <> Enum.join(error, ", ")], acc + 1}
        end
     end)
+    if errorcount == length(msgs) and errorcount > 0 do
+      {:error, {msgs, errorcount}}
+    else
+      {:ok, {msgs, errorcount}}
+    end
   end
 end

--- a/lib/cogctl/actions/relays/util.ex
+++ b/lib/cogctl/actions/relays/util.ex
@@ -12,7 +12,17 @@ defmodule Cogctl.Actions.Relays.Util do
 
   def get_status(true), do: "enabled"
   def get_status(false), do: "disabled"
+  def get_status(value), do: value
 
+  # If the errorcount is not equal to 0, be sure that an error code
+  # is returned upon execution
+  def render(relay, {relay_group_msgs, 0}) do
+    render_output(relay_group_msgs, relay)
+  end
+  def render(relay, {relay_group_msgs, _errorcount}) do
+    render_output(relay_group_msgs, relay)
+    :error
+  end
   def render(relay_info, sort) do
     Table.format(relay_info, sort) |> display_output
   end
@@ -60,6 +70,13 @@ defmodule Cogctl.Actions.Relays.Util do
     end
   end
 
+  defp render_output(relay_group_msgs, relay) do
+    relay_info = format_table(relay)
+
+    Table.format(relay_info, false) <> "\n\n" <> Table.format(relay_group_msgs, false)
+    |> display_output
+  end
+
   defp render_output(relay_group_messages, relay_info, sort) do
     group_message = Enum.join(relay_group_messages, "\n")
     Table.format(relay_info, sort) <> "\n\n" <> group_message
@@ -71,4 +88,13 @@ defmodule Cogctl.Actions.Relays.Util do
     message <> group_message <> "\n\n" <> Table.format(relay_info, sort)
     |> display_output
   end
+
+  defp format_table(relay) do
+    [
+      {"ID",     relay.id},
+      {"Name",   relay.name},
+      {"Status", get_status(relay.enabled)},
+    ]
+  end
+
 end

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -494,9 +494,17 @@ defmodule CogctlTest do
     """
 
     assert run("cogctl relays create test-relay --token=hola --description='Hola, Como estas'") =~ ~r"""
-    ID    .*
-    Name  test-relay
+    ID      .*
+    Name    test-relay
+    Status  disabled
     """
+
+    assert run("cogctl relays create test-relay2 --enable --token=hola --description='Hola, mi amigo'") =~ ~r"""
+    ID      .*
+    Name    test-relay2
+    Status  enabled
+    """
+    run("cogctl relays delete test-relay2")
 
     assert run("cogctl relays enable test-relay") =~ ~r"""
     Enabled test-relay
@@ -537,9 +545,10 @@ defmodule CogctlTest do
 
     run("cogctl relay-groups create mygroup")
 
-    assert run("cogctl relays create --groups=group,mygroup test-relay --token=hola") =~ ~r"""
-    ID    .*
-    Name  test-relay
+    assert run("cogctl relays create --enable --groups=group,mygroup test-relay --token=hola") =~ ~r"""
+    ID      .*
+    Name    test-relay
+    Status  enabled
 
     Adding 'test-relay' to relay group 'group': Error. Resource not found for: 'relay_groups'
     Adding 'test-relay' to relay group 'mygroup': Ok.


### PR DESCRIPTION
This PR adds the enable flag to the options available for `relays create`. There was a need for a slight restructure since this would be done upon the successful creation of a relay.

Connected to https://github.com/operable/cog/issues/566