### PR TITLE
OptParse updates

### DIFF
--- a/lib/cogctl.ex
+++ b/lib/cogctl.ex
@@ -28,13 +28,15 @@ defmodule Cogctl do
         :ok
       :error ->
         exit({:shutdown, 1})
+      {:error, msg} ->
+        exit_with_error(msg)
       error ->
-        display_error(error)
+        exit_with_error("ERROR: #{inspect(error)}")
     end
   end
 
-  defp display_error(error) do
-    IO.puts "Error: #{inspect error}"
+  defp exit_with_error(error) do
+    IO.puts(:stderr, "cogctl: #{error}")
     exit({:shutdown, 1})
   end
 

--- a/lib/cogctl/actions/bundles/create.ex
+++ b/lib/cogctl/actions/bundles/create.ex
@@ -28,22 +28,15 @@ defmodule Cogctl.Actions.Bundles.Create do
   """
 
   def option_spec do
-    [{:file, :undefined, :undefined, {:string, :undefined}, 'Path to your bundle config file (required)'},
+    [{:file, :undefined, :undefined, :string, 'Path to your bundle config file (required)'},
      {:templates, :undefined, 'templates', {:string, 'templates'}, 'Path to your template directory'},
      {:enabled, :undefined, 'enable', {:boolean, false}, 'Enable bundle after installing'},
-     {:"relay-groups", :undefined, 'relay-groups', {:string, :undefined}, 'List of relay group names separated by commas to assign the bundle'}]
+     {:"relay-groups", :undefined, 'relay-groups', {:list, :undefined}, 'List of relay group names separated by commas to assign the bundle'}]
   end
 
   def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, [file: :required,
-                                     templates: :required,
-                                     enabled: :optional,
-                                     "relay-groups": :optional]) do
-      {:ok, params} ->
-        with_authentication(endpoint, &do_create(&1, params))
-      {:error, {:missing_params, missing_params}} ->
-        display_arguments_error(missing_params)
-    end
+    params = convert_to_params(options)
+    with_authentication(endpoint, &do_create(&1, params))
   end
 
   defp do_create(endpoint, params) do
@@ -94,9 +87,7 @@ defmodule Cogctl.Actions.Bundles.Create do
     Client.bundle_create(endpoint, params)
   end
 
-  defp assign_to_relay_groups(endpoint, bundle, %{"relay-groups": relay_group_names}) do
-    relay_groups = String.split(relay_group_names, ",")
-
+  defp assign_to_relay_groups(endpoint, bundle, %{"relay-groups": relay_groups}) do
     Enum.map(relay_groups, fn relay_group ->
       result = Client.relay_group_add_bundles_by_name(relay_group, bundle.name, endpoint)
 

--- a/lib/cogctl/actions/bundles/disable.ex
+++ b/lib/cogctl/actions/bundles/disable.ex
@@ -2,7 +2,7 @@ defmodule Cogctl.Actions.Bundles.Disable do
   use Cogctl.Action, "bundles disable"
 
   def option_spec() do
-    [{:bundle, :undefined, :undefined, {:string, :undefined}, 'Bundle name'}]
+    [{:bundle, :undefined, :undefined, :string, 'Bundle name (required)'}]
   end
 
   def run(options, _args,  _config, endpoint) do

--- a/lib/cogctl/actions/bundles/enable.ex
+++ b/lib/cogctl/actions/bundles/enable.ex
@@ -2,7 +2,7 @@ defmodule Cogctl.Actions.Bundles.Enable do
   use Cogctl.Action, "bundles enable"
 
   def option_spec() do
-    [{:bundle, :undefined, :undefined, {:string, :undefined}, 'Bundle name (required)'}]
+    [{:bundle, :undefined, :undefined, :string, 'Bundle name (required)'}]
   end
 
   def run(options, _args,  _config, endpoint) do

--- a/lib/cogctl/actions/bundles/info.ex
+++ b/lib/cogctl/actions/bundles/info.ex
@@ -4,16 +4,12 @@ defmodule Cogctl.Actions.Bundles.Info do
   alias Cogctl.Table
 
   def option_spec do
-    [{:bundle, :undefined, :undefined, {:string, :undefined}, 'Bundle name (required)'}]
+    [{:bundle, :undefined, :undefined, :string, 'Bundle name (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do
     with_authentication(endpoint,
                         &do_info(&1, :proplists.get_value(:bundle, options)))
-  end
-
-  defp do_info(_endpoint, :undefined) do
-    display_error("Missing required arguments")
   end
 
   defp do_info(endpoint, bundle_name) do

--- a/lib/cogctl/actions/chat_handles/create.ex
+++ b/lib/cogctl/actions/chat_handles/create.ex
@@ -3,20 +3,14 @@ defmodule Cogctl.Actions.ChatHandles.Create do
   alias Cogctl.Table
 
   def option_spec do
-    [{:user, :undefined, 'user', {:string, :undefined}, 'Username of user to add handle to (required)'},
-     {:chat_provider, :undefined, 'chat-provider', {:string, :undefined}, 'Chat provider name (required)'},
+    [{:user, :undefined, 'user', :string, 'Username of user to add handle to (required)'},
+     {:chat_provider, :undefined, 'chat-provider', :string, 'Chat provider name (required)'},
      {:handle, :undefined, 'handle', {:string, :undefined}, 'Handle (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, [user: :required,
-                                     chat_provider: :required,
-                                     handle: :required]) do
-      {:ok, params} ->
-        with_authentication(endpoint, &do_create(&1, params))
-      {:error, {:missing_params, missing_params}} ->
-        display_arguments_error(missing_params)
-    end
+    params = convert_to_params(options)
+    with_authentication(endpoint, &do_create(&1, params))
   end
 
   defp do_create(endpoint, params) do

--- a/lib/cogctl/actions/chat_handles/delete.ex
+++ b/lib/cogctl/actions/chat_handles/delete.ex
@@ -2,18 +2,13 @@ defmodule Cogctl.Actions.ChatHandles.Delete do
   use Cogctl.Action, "chat-handles delete"
 
   def option_spec do
-    [{:user, :undefined, 'user', {:string, :undefined}, 'Username user that owns the handle to delete (required)'},
-     {:chat_provider, :undefined, 'chat-provider', {:string, :undefined}, 'Chat provider name (required)'}]
+    [{:user, :undefined, 'user', :string, 'Username user that owns the handle to delete (required)'},
+     {:chat_provider, :undefined, 'chat-provider', :string, 'Chat provider name (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, [user: :required,
-                                     chat_provider: :required]) do
-      {:ok, params} ->
-        with_authentication(endpoint, &do_delete(&1, params))
-      {:error, {:missing_params, missing_params}} ->
-        display_arguments_error(missing_params)
-    end
+    params = convert_to_params(options)
+    with_authentication(endpoint, &do_delete(&1, params))
   end
 
   defp do_delete(endpoint, params) do

--- a/lib/cogctl/actions/groups/add.ex
+++ b/lib/cogctl/actions/groups/add.ex
@@ -6,8 +6,8 @@ defmodule Cogctl.Actions.Groups.Add do
   alias CogApi.HTTP.Client
 
   def option_spec do
-    [{:group, :undefined, :undefined, {:string, :undefined}, 'Group name (required)'},
-     {:email, :undefined, 'email', {:string, :undefined}, 'User email address (required)'}]
+    [{:group, :undefined, :undefined, :string, 'Group name (required)'},
+     {:email, :undefined, 'email', :string, 'User email address (required)'}]
   end
 
   def run(options, args, config, %{token: nil}=endpoint) do

--- a/lib/cogctl/actions/groups/create.ex
+++ b/lib/cogctl/actions/groups/create.ex
@@ -5,7 +5,7 @@ defmodule Cogctl.Actions.Groups.Create do
   alias CogApi.HTTP.Client
 
   def option_spec do
-    [{:name, :undefined, :undefined, {:string, :undefined}, 'Group name (required)'}]
+    [{:name, :undefined, :undefined, :string, 'Group name (required)'}]
   end
 
   def run(options, _args, _config, %{token: nil}=endpoint) do

--- a/lib/cogctl/actions/groups/delete.ex
+++ b/lib/cogctl/actions/groups/delete.ex
@@ -5,7 +5,7 @@ defmodule Cogctl.Actions.Groups.Delete do
   alias CogApi.HTTP.Client
 
   def option_spec do
-    [{:group, :undefined, :undefined, {:string, :undefined}, 'Group name (required)'}]
+    [{:group, :undefined, :undefined, :string, 'Group name (required)'}]
   end
 
   def run(options, _args, _config, %{token: nil}=endpoint) do

--- a/lib/cogctl/actions/groups/info.ex
+++ b/lib/cogctl/actions/groups/info.ex
@@ -4,7 +4,7 @@ defmodule Cogctl.Actions.Groups.Info do
   alias Cogctl.Actions.Groups
 
   def option_spec do
-    [{:group, :undefined, :undefined, {:string, :undefined}, 'Group name (required)'}]
+    [{:group, :undefined, :undefined, :string, 'Group name (required)'}]
   end
 
   def run(options, _args, _config, %{token: nil}=endpoint) do

--- a/lib/cogctl/actions/groups/remove.ex
+++ b/lib/cogctl/actions/groups/remove.ex
@@ -6,8 +6,8 @@ defmodule Cogctl.Actions.Groups.Remove do
   alias CogApi.HTTP.Client
 
   def option_spec do
-    [{:group, :undefined, :undefined, {:string, :undefined}, 'Group name (required)'},
-     {:email, :undefined, 'email', {:string, :undefined}, 'User email address (required)'}]
+    [{:group, :undefined, :undefined, :string, 'Group name (required)'},
+     {:email, :undefined, 'email', :string, 'User email address (required)'}]
   end
 
   def run(options, _args, _config, %{token: nil}=endpoint) do

--- a/lib/cogctl/actions/groups/rename.ex
+++ b/lib/cogctl/actions/groups/rename.ex
@@ -5,8 +5,8 @@ defmodule Cogctl.Actions.Groups.Rename do
   alias CogApi.HTTP.Client
 
   def option_spec do
-    [{:group, :undefined, :undefined, {:string, :undefined}, 'Group id (required)'},
-     {:name, :undefined, :undefined, {:string, :undefined}, 'Name (required)'}]
+    [{:group, :undefined, :undefined, :string, 'Group id (required)'},
+     {:name, :undefined, :undefined, :string, 'Name (required)'}]
   end
 
   def run(options, _args, _config, %{token: nil}=endpoint) do

--- a/lib/cogctl/actions/permissions.ex
+++ b/lib/cogctl/actions/permissions.ex
@@ -7,15 +7,11 @@ defmodule Cogctl.Actions.Permissions do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options, role: :optional)
+    params = convert_to_params(options)
     with_authentication(endpoint, &do_list(&1, params))
   end
 
-  defp do_list(_endpoint, {:error, {:missing_params, missing_params}}) do
-    display_arguments_error(missing_params)
-  end
-
-  defp do_list(endpoint, {:ok, params}) do
+  defp do_list(endpoint, params) do
     case CogApi.HTTP.Internal.permission_index(endpoint, params) do
       {:ok, resp} ->
         permissions = resp["permissions"]

--- a/lib/cogctl/actions/permissions/create.ex
+++ b/lib/cogctl/actions/permissions/create.ex
@@ -4,7 +4,7 @@ defmodule Cogctl.Actions.Permissions.Create do
   alias Cogctl.Actions.Permissions.View, as: PermissionView
 
   def option_spec do
-    [{:name, :undefined, :undefined, {:string, :undefined}, 'Permission name (required)'}]
+    [{:name, :undefined, :undefined, :string, 'Permission name (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do

--- a/lib/cogctl/actions/permissions/delete.ex
+++ b/lib/cogctl/actions/permissions/delete.ex
@@ -2,7 +2,7 @@ defmodule Cogctl.Actions.Permissions.Delete do
   use Cogctl.Action, "permissions delete"
 
   def option_spec do
-    [{:permission, :undefined, :undefined, {:string, :undefined}, 'Permission name (required)'}]
+    [{:permission, :undefined, :undefined, :string, 'Permission name (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do

--- a/lib/cogctl/actions/permissions/grant.ex
+++ b/lib/cogctl/actions/permissions/grant.ex
@@ -2,8 +2,8 @@ defmodule Cogctl.Actions.Permissions.Grant do
   use Cogctl.Action, "permissions grant"
 
   def option_spec do
-    [{:permission, :undefined, :undefined, {:string, :undefined}, 'Permission name (required)'},
-     {:role, :undefined, 'role', {:string, :undefined}, 'Role name (required)'}]
+    [{:permission, :undefined, :undefined, :string, 'Permission name (required)'},
+     {:role, :undefined, 'role', :string, 'Role name (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do

--- a/lib/cogctl/actions/permissions/revoke.ex
+++ b/lib/cogctl/actions/permissions/revoke.ex
@@ -2,7 +2,7 @@ defmodule Cogctl.Actions.Permissions.Revoke do
   use Cogctl.Action, "permissions revoke"
 
   def option_spec do
-    [{:permission, :undefined, :undefined, {:string, :undefined}, 'Permission name (required)'},
+    [{:permission, :undefined, :undefined, :string, 'Permission name (required)'},
      {:role_to_revoke, :undefined, 'role', {:string, :undefined}, 'Role to revoke permission from'}]
   end
 

--- a/lib/cogctl/actions/relay_groups/add.ex
+++ b/lib/cogctl/actions/relay_groups/add.ex
@@ -9,19 +9,14 @@ defmodule Cogctl.Actions.RelayGroups.Add do
   """
 
   def option_spec() do
-    [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
-     {:relays, :undefined, 'relays', {:list, :undefined}, 'Relay names (required)'}]
+    [{:relay_group, :undefined, :undefined, :string, 'Relay Group name (required)'},
+     {:relays, :undefined, 'relays', :list, 'Relay names (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do
     # At least one relay is required, so we specify that here
-    case convert_to_params(options, option_spec, [relay_group: :required,
-                                                  relays: :required]) do
-      {:ok, params} ->
-        with_authentication(endpoint, &do_add(&1, params))
-      {:error, {:missing_params, missing_args}} ->
-        display_arguments_error(missing_args)
-    end
+    params = convert_to_params(options)
+    with_authentication(endpoint, &do_add(&1, params))
   end
 
   defp do_add(endpoint, params) do

--- a/lib/cogctl/actions/relay_groups/assign.ex
+++ b/lib/cogctl/actions/relay_groups/assign.ex
@@ -12,20 +12,13 @@ defmodule Cogctl.Actions.RelayGroups.Assign do
   """
 
   def option_spec() do
-    [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
-     {:bundles, :undefined, 'bundles', {:list, :undefined}, 'Bundle names (required)'}]
+    [{:relay_group, :undefined, :undefined, :string, 'Relay Group name (required)'},
+     {:bundles, :undefined, 'bundles', :list, 'Bundle names (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do
-    # At least one bundle is required, so we specify that here
-    case convert_to_params(options, option_spec, [relay_group: :required,
-                                                  bundles: :required]) do
-      {:ok, params} ->
-        # The rest of the bundles, if there are any, get appended here.
-        with_authentication(endpoint, &do_assign(&1, params))
-      {:error, {:missing_params, missing_params}} ->
-        display_arguments_error(missing_params)
-    end
+    params = convert_to_params(options)
+    with_authentication(endpoint, &do_assign(&1, params))
   end
 
   defp do_assign(endpoint, params) do

--- a/lib/cogctl/actions/relay_groups/create.ex
+++ b/lib/cogctl/actions/relay_groups/create.ex
@@ -3,7 +3,7 @@ defmodule Cogctl.Actions.RelayGroups.Create do
   import Cogctl.Actions.RelayGroups.Util, only: [render: 2, render: 3]
 
   def option_spec do
-    [{:name, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
+    [{:name, :undefined, :undefined, :string, 'Relay Group name (required)'},
      {:members, :undefined, 'members', {:list, :undefined}, 'Relay names'}]
   end
 
@@ -11,13 +11,8 @@ defmodule Cogctl.Actions.RelayGroups.Create do
     with_authentication(endpoint, &run(options, nil, nil, &1))
   end
   def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, option_spec, [name: :required,
-                                                  members: :optional]) do
-      {:ok, params} ->
-        do_create(endpoint, params)
-      {:error, {:missing_params, missing_params}} ->
-        display_arguments_error(missing_params)
-    end
+    params = convert_to_params(options)
+    do_create(endpoint, params)
   end
 
   defp do_create(endpoint, params) do

--- a/lib/cogctl/actions/relay_groups/info.ex
+++ b/lib/cogctl/actions/relay_groups/info.ex
@@ -3,7 +3,7 @@ defmodule Cogctl.Actions.RelayGroups.Info do
   import Cogctl.Actions.RelayGroups.Util, only: [get_details: 1, render: 5]
 
   def option_spec do
-    [{:name, :undefined, :undefined, {:string, :undefined}, 'Relay name (required)'}]
+    [{:name, :undefined, :undefined, :string, 'Relay name (required)'}]
   end
 
   def run(options, _args, _config, %{token: nil}=endpoint) do

--- a/lib/cogctl/actions/relay_groups/remove.ex
+++ b/lib/cogctl/actions/relay_groups/remove.ex
@@ -9,18 +9,13 @@ defmodule Cogctl.Actions.RelayGroups.Remove do
   """
 
   def option_spec() do
-    [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
-     {:relays, :undefined, 'relays', {:list, :undefined}, 'Relay names (required)'}]
+    [{:relay_group, :undefined, :undefined, :string, 'Relay Group name (required)'},
+     {:relays, :undefined, 'relays', :list, 'Relay names (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, option_spec, [relay_group: :required,
-                                                  relays: :required]) do
-      {:ok, params} ->
-        with_authentication(endpoint, &do_remove(&1, params))
-      {:error, {:missing_params, missing_params}} ->
-        display_arguments_error(missing_params)
-    end
+    params = convert_to_params(options)
+    with_authentication(endpoint, &do_remove(&1, params))
   end
 
   defp do_remove(endpoint, params) do

--- a/lib/cogctl/actions/relay_groups/unassign.ex
+++ b/lib/cogctl/actions/relay_groups/unassign.ex
@@ -12,20 +12,13 @@ defmodule Cogctl.Actions.RelayGroups.Unassign do
   """
 
   def option_spec() do
-    [{:relay_group, :undefined, :undefined, {:string, :undefined}, 'Relay Group name (required)'},
-     {:bundles, :undefined, 'bundles', {:list, :undefined}, 'Bundle names (required)'}]
+    [{:relay_group, :undefined, :undefined, :string, 'Relay Group name (required)'},
+     {:bundles, :undefined, 'bundles', :list, 'Bundle names (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do
-    # At least one bundle is required, so we specify that here
-    case convert_to_params(options, option_spec, [relay_group: :required,
-                                                  bundles: :required]) do
-      {:ok, params} ->
-        # The rest of the bundles, if there are any, get appended here.
-        with_authentication(endpoint, &do_unassign(&1, params))
-      {:error, {:missing_params, missing_params}} ->
-        display_arguments_error(missing_params)
-    end
+    params = convert_to_params(options)
+    with_authentication(endpoint, &do_unassign(&1, params))
   end
 
   defp do_unassign(endpoint, params) do

--- a/lib/cogctl/actions/relays/create.ex
+++ b/lib/cogctl/actions/relays/create.ex
@@ -3,29 +3,17 @@ defmodule Cogctl.Actions.Relays.Create do
   alias Cogctl.Actions.Relays.Util
 
   def option_spec do
-    [{:name, :undefined, :undefined, {:string, :undefined}, 'Relay name (required)'},
-     {:token, :undefined, 'token', {:string, :undefined}, 'Relay token (required)'},
+    [{:name, :undefined, :undefined, :string, 'Relay name (required)'},
+     {:token, :undefined, 'token', :string, 'Relay token (required)'},
      {:enable, :undefined, 'enable', {:boolean, false}, 'Flag to enable the relay (default false)'},
      {:description, :undefined, 'description', {:string, :undefined}, 'Relay description'},
      {:groups, :undefined, 'groups', {:list, :undefined}, 'Relay groups'},
      {:id, :undefined, 'id', {:string, :undefined}, 'Relay id (must be uuid)'}]
   end
 
-  def run(options, _args, _config, %{token: nil}=endpoint) do
-    with_authentication(endpoint, &run(options, nil, nil, &1))
-  end
   def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, option_spec, [name: :required,
-                                                  token: :required,
-                                                  enable: :optional,
-                                                  description: :optional,
-                                                  groups: :optional,
-                                                  id: :optional]) do
-      {:ok, params} ->
-        do_create(endpoint, params)
-      {:error, {:missing_params, missing_params}} ->
-        display_arguments_error(missing_params)
-    end
+    params = convert_to_params(options)
+    with_authentication(endpoint, &do_create(&1, params))
   end
 
   defp do_create(endpoint, params) do

--- a/lib/cogctl/actions/relays/disable.ex
+++ b/lib/cogctl/actions/relays/disable.ex
@@ -3,7 +3,7 @@ defmodule Cogctl.Actions.Relays.Disable do
   import Cogctl.Actions.Relays.Util, only: [update_status: 3]
 
   def option_spec() do
-    [{:relay, :undefined, :undefined, {:string, :undefined}, 'Relay name (required)'}]
+    [{:relay, :undefined, :undefined, :string, 'Relay name (required)'}]
   end
 
   def run(options, _args, _config, %{token: nil}=endpoint) do

--- a/lib/cogctl/actions/relays/enable.ex
+++ b/lib/cogctl/actions/relays/enable.ex
@@ -3,7 +3,7 @@ defmodule Cogctl.Actions.Relays.Enable do
   import Cogctl.Actions.Relays.Util, only: [update_status: 3]
 
   def option_spec() do
-    [{:relay, :undefined, :undefined, {:string, :undefined}, 'Relay name (required)'}]
+    [{:relay, :undefined, :undefined, :string, 'Relay name (required)'}]
   end
 
   def run(options, _args, _config, %{token: nil}=endpoint) do

--- a/lib/cogctl/actions/relays/info.ex
+++ b/lib/cogctl/actions/relays/info.ex
@@ -3,7 +3,7 @@ defmodule Cogctl.Actions.Relays.Info do
   import Cogctl.Actions.Relays.Util, only: [get_details: 1, render: 4]
 
   def option_spec do
-    [{:relay, :undefined, :undefined, {:string, :undefined}, 'Relay name (required)'}]
+    [{:relay, :undefined, :undefined, :string, 'Relay name (required)'}]
   end
 
   def run(options, _args, _config, %{token: nil}=endpoint) do

--- a/lib/cogctl/actions/relays/update.ex
+++ b/lib/cogctl/actions/relays/update.ex
@@ -3,25 +3,15 @@ defmodule Cogctl.Actions.Relays.Update do
   import Cogctl.Actions.Relays.Util, only: [get_details: 1, render: 4]
 
   def option_spec do
-    [{:relay, :undefined, :undefined, {:string, :undefined}, 'Current Relay name (required)'},
+    [{:relay, :undefined, :undefined, :string, 'Current Relay name (required)'},
      {:name, :undefined, 'name', {:string, :undefined}, 'name'},
      {:token, :undefined, 'token', {:string, :undefined}, 'token'},
      {:description, :undefined, 'description', {:string, :undefined}, 'description'}]
   end
 
-  def run(options, _args, _config, %{token: nil}=endpoint) do
-    with_authentication(endpoint, &run(options, nil, nil, &1))
-  end
   def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, [relay: :required,
-                                     name: :optional,
-                                     token: :optional,
-                                     description: :optional]) do
-      {:ok, params} ->
-        do_update(endpoint, params)
-      {:error, {:missing_params, missing_params}} ->
-        display_arguments_error(missing_params)
-    end
+    params = convert_to_params(options)
+    with_authentication(endpoint, &do_update(&1, params))
   end
 
   defp do_update(endpoint, params) do

--- a/lib/cogctl/actions/roles/create.ex
+++ b/lib/cogctl/actions/roles/create.ex
@@ -3,7 +3,7 @@ defmodule Cogctl.Actions.Roles.Create do
   alias Cogctl.Table
 
   def option_spec do
-    [{:name, :undefined, :undefined, {:string, :undefined}, 'Role name (required)'}]
+    [{:name, :undefined, :undefined, :string, 'Role name (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do

--- a/lib/cogctl/actions/roles/delete.ex
+++ b/lib/cogctl/actions/roles/delete.ex
@@ -2,7 +2,7 @@ defmodule Cogctl.Actions.Roles.Delete do
   use Cogctl.Action, "roles delete"
 
   def option_spec do
-    [{:role, :undefined, :undefined, {:string, :undefined}, 'Role name (required)'}]
+    [{:role, :undefined, :undefined, :string, 'Role name (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do

--- a/lib/cogctl/actions/roles/grant.ex
+++ b/lib/cogctl/actions/roles/grant.ex
@@ -6,8 +6,8 @@ defmodule Cogctl.Actions.Roles.Grant do
   alias Cogctl.Actions.Roles
 
   def option_spec do
-    [{:role, :undefined, :undefined, {:string, :undefined}, 'Role name (required)'},
-     {:group, :undefined, 'group', {:string, :undefined}, 'Group name (required)'}]
+    [{:role, :undefined, :undefined, :string, 'Role name (required)'},
+     {:group, :undefined, 'group', :string, 'Group name (required)'}]
   end
 
   def run(options, _args, _config, %{token: nil}=endpoint) do

--- a/lib/cogctl/actions/roles/info.ex
+++ b/lib/cogctl/actions/roles/info.ex
@@ -3,20 +3,14 @@ defmodule Cogctl.Actions.Roles.Info do
   import Cogctl.Actions.Roles.Util, only: [render: 3]
 
   def option_spec do
-    [{:role, :undefined, :undefined, {:string, :undefined}, 'Role name (required)'},
+    [{:role, :undefined, :undefined, :string, 'Role name (required)'},
      {:permissions, :undefined, 'permissions', {:boolean, false}, 'Flag to display Permissions data'},
      {:groups, :undefined, 'groups', {:boolean, false}, 'Flag to display Groups data'}]
   end
 
   def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, option_spec, [role: :required,
-                                                  permissions: :optional,
-                                                  groups: :optional]) do
-      {:ok, params} ->
-        with_authentication(endpoint, &do_info(&1, params))
-      {:error, {:missing_params, missing_args}} ->
-        display_arguments_error(missing_args)
-    end
+    params = convert_to_params(options)
+    with_authentication(endpoint, &do_info(&1, params))
   end
 
   defp do_info(endpoint, params) do

--- a/lib/cogctl/actions/roles/rename.ex
+++ b/lib/cogctl/actions/roles/rename.ex
@@ -3,25 +3,17 @@ defmodule Cogctl.Actions.Roles.Rename do
   alias Cogctl.Table
 
   def option_spec do
-    [{:role, :undefined, :undefined, {:string, :undefined}, 'Role id (required)'},
+    [{:role, :undefined, :undefined, :string, 'Role id (required)'},
      {:name, :undefined, :undefined, {:string, :undefined}, 'Name'}]
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options, [name: :optional])
+    params = convert_to_params(options)
     with_authentication(endpoint,
                         &do_rename(&1, :proplists.get_value(:role, options), params))
   end
 
-  defp do_rename(_endpoint, :undefined, _params) do
-    display_arguments_error("role")
-  end
-
-  defp do_rename(_endpoint, _role_name, {:error, {:missing_params, missing_params}}) do
-    display_arguments_error(missing_params)
-  end
-
-  defp do_rename(endpoint, role_name, {:ok, params}) do
+  defp do_rename(endpoint, role_name, params) do
     case CogApi.HTTP.Internal.role_update(endpoint, role_name, %{role: params}) do
       {:ok, resp} ->
         role = resp["role"]

--- a/lib/cogctl/actions/roles/revoke.ex
+++ b/lib/cogctl/actions/roles/revoke.ex
@@ -2,7 +2,7 @@ defmodule Cogctl.Actions.Roles.Revoke do
   use Cogctl.Action, "roles revoke"
 
   def option_spec do
-    [{:role, :undefined, :undefined, {:string, :undefined}, 'Role name (required)'},
+    [{:role, :undefined, :undefined, :string, 'Role name (required)'},
      {:group_to_revoke, :undefined, 'group', {:string, :undefined}, 'Name of group to revoke role from'}]
   end
 

--- a/lib/cogctl/actions/rules.ex
+++ b/lib/cogctl/actions/rules.ex
@@ -3,7 +3,7 @@ defmodule Cogctl.Actions.Rules do
   alias Cogctl.Table
 
   def option_spec do
-    [{:command, :undefined, :undefined, {:string, :undefined}, 'Full command name including bundle name (required), Ex.: "operable:echo"'}]
+    [{:command, :undefined, :undefined, :string, 'Full command name including bundle name (required), Ex.: "operable:echo"'}]
   end
 
   def run(options, _args, _config, endpoint) do

--- a/lib/cogctl/actions/rules/create.ex
+++ b/lib/cogctl/actions/rules/create.ex
@@ -3,16 +3,12 @@ defmodule Cogctl.Actions.Rules.Create do
   alias Cogctl.Table
 
   def option_spec do
-    [{:rule_text, ?r, 'rule-text', {:string, :undefined}, 'Text of the rule (required)'}]
+    [{:rule_text, ?r, 'rule-text', :string, 'Text of the rule (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do
     with_authentication(endpoint,
                         &do_create(&1, :proplists.get_value(:rule_text, options)))
-  end
-
-  defp do_create(_endpoint, :undefined) do
-    display_arguments_error
   end
 
   defp do_create(endpoint, rule_text) do

--- a/lib/cogctl/actions/rules/delete.ex
+++ b/lib/cogctl/actions/rules/delete.ex
@@ -2,16 +2,12 @@ defmodule Cogctl.Actions.Rules.Delete do
   use Cogctl.Action, "rules delete"
 
   def option_spec do
-    [{:rule, :undefined, :undefined, {:string, :undefined}, 'Rule id'}]
+    [{:rule, :undefined, :undefined, :string, 'Rule id (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do
     with_authentication(endpoint,
                         &do_delete(&1, :proplists.get_value(:rule, options)))
-  end
-
-  defp do_delete(_endpoint, :undefined) do
-    display_arguments_error
   end
 
   defp do_delete(endpoint, rule_id) do

--- a/lib/cogctl/actions/triggers/create.ex
+++ b/lib/cogctl/actions/triggers/create.ex
@@ -4,8 +4,8 @@ defmodule Cogctl.Actions.Triggers.Create do
   alias Cogctl.Actions.Triggers.Util
 
   def option_spec do
-    [{:name, :undefined, 'name', {:string, :undefined}, 'Trigger name (required)'},
-     {:pipeline, :undefined, 'pipeline', {:string, :undefined}, 'Pipeline text (required)'},
+    [{:name, :undefined, 'name', :string, 'Trigger name (required)'},
+     {:pipeline, :undefined, 'pipeline', :string, 'Pipeline text (required)'},
      {:enabled, :undefined, 'enabled', {:boolean, :undefined}, 'Enabled'},
      {:as_user, :undefined, 'as-user', {:string, :undefined}, 'User to execute pipeline as'},
      {:timeout_sec, :undefined, 'timeout-sec', {:string, :undefined}, 'Timeout (seconds)'},
@@ -13,17 +13,8 @@ defmodule Cogctl.Actions.Triggers.Create do
   end
 
   def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, [name: :required,
-                                     pipeline: :required,
-                                     enabled: :optional,
-                                     as_user: :optional,
-                                     timeout_sec: :optional,
-                                     description: :optional]) do
-      {:ok, params} ->
-        with_authentication(endpoint, &do_create(&1, params))
-      {:error, {:missing_params, missing_params}} ->
-        display_arguments_error(missing_params)
-    end
+    params = convert_to_params(options)
+    with_authentication(endpoint, &do_create(&1, params))
   end
 
   defp do_create(endpoint, params) do

--- a/lib/cogctl/actions/triggers/delete.ex
+++ b/lib/cogctl/actions/triggers/delete.ex
@@ -2,7 +2,7 @@ defmodule Cogctl.Actions.Triggers.Delete do
   use Cogctl.Action, "triggers delete"
 
   def option_spec do
-    [{:name, :undefined, :undefined, {:string, :undefined}, 'name'}]
+    [{:name, :undefined, :undefined, :string, 'name (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do

--- a/lib/cogctl/actions/triggers/disable.ex
+++ b/lib/cogctl/actions/triggers/disable.ex
@@ -3,7 +3,7 @@ defmodule Cogctl.Actions.Triggers.Disable do
   alias Cogctl.Actions.Triggers.Util
 
   def option_spec() do
-    [{:trigger, :undefined, :undefined, {:string, :undefined}, 'Trigger name (required)'}]
+    [{:trigger, :undefined, :undefined, :string, 'Trigger name (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do

--- a/lib/cogctl/actions/triggers/enable.ex
+++ b/lib/cogctl/actions/triggers/enable.ex
@@ -3,7 +3,7 @@ defmodule Cogctl.Actions.Triggers.Enable do
   alias Cogctl.Actions.Triggers.Util
 
   def option_spec() do
-    [{:trigger, :undefined, :undefined, {:string, :undefined}, 'Trigger name (required)'}]
+    [{:trigger, :undefined, :undefined, :string, 'Trigger name (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do

--- a/lib/cogctl/actions/triggers/info.ex
+++ b/lib/cogctl/actions/triggers/info.ex
@@ -5,7 +5,7 @@ defmodule Cogctl.Actions.Triggers.Info do
   alias Cogctl.Actions.Triggers.Util
 
   def option_spec do
-    [{:name, :undefined, :undefined, {:string, :undefined}, 'Trigger name (required)'}]
+    [{:name, :undefined, :undefined, :string, 'Trigger name (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do

--- a/lib/cogctl/actions/triggers/update.ex
+++ b/lib/cogctl/actions/triggers/update.ex
@@ -4,7 +4,7 @@ defmodule Cogctl.Actions.Triggers.Update do
   alias Cogctl.Actions.Triggers.Util
   def option_spec do
     [
-      {:trigger, :undefined, :undefined, {:string, :undefined}, 'Trigger name (required)'},
+      {:trigger, :undefined, :undefined, :string, 'Trigger name (required)'},
 
       {:name, :undefined, 'name', {:string, :undefined}, 'Trigger name'},
       {:pipeline, :undefined, 'pipeline', {:string, :undefined}, 'Pipeline text'},
@@ -15,21 +15,10 @@ defmodule Cogctl.Actions.Triggers.Update do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options, [name: :optional,
-                                         pipeline: :optional,
-                                         enabled: :optional,
-                                         as_user: :optional,
-                                         timeout_sec: :optional,
-                                         description: :optional])
+    params = convert_to_params(options)
     name = :proplists.get_value(:trigger, options)
 
-    case {name, params} do
-      {name, {:ok, params}} when is_binary(name) ->
-        with_authentication(endpoint,
-                            &do_update(&1, name, params))
-      {:error, {:missing_params, missing_params}} ->
-        display_arguments_error(missing_params)
-    end
+    with_authentication(endpoint, &do_update(&1, name, params))
   end
 
   defp do_update(endpoint, trigger_name, params) do

--- a/lib/cogctl/actions/users/create.ex
+++ b/lib/cogctl/actions/users/create.ex
@@ -8,26 +8,18 @@ defmodule Cogctl.Actions.Users.Create do
   def option_spec do
     [{:first_name, :undefined, 'first-name', {:string, :undefined}, 'First name'},
      {:last_name, :undefined, 'last-name', {:string, :undefined}, 'Last name'},
-     {:email_address, :undefined, 'email', {:string, :undefined}, 'Email address (required)'},
-     {:username, :undefined, 'username', {:string, :undefined}, 'Username (required)'},
-     {:password, :undefined, 'password', {:string, :undefined}, 'Password (required)'}]
+     {:email_address, :undefined, 'email', :string, 'Email address (required)'},
+     {:username, :undefined, 'username', :string, 'Username (required)'},
+     {:password, :undefined, 'password', :string, 'Password (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options, [first_name: :optional,
-                                         last_name: :optional,
-                                         email_address: :required,
-                                         username: :required,
-                                         password: :required])
+    params = convert_to_params(options)
 
     with_authentication(endpoint, &do_create(&1, params))
   end
 
-  defp do_create(_endpoint, {:error, {:missing_params, missing_params}}) do
-    display_arguments_error(missing_params)
-  end
-
-  defp do_create(endpoint, {:ok, params}) do
+  defp do_create(endpoint, params) do
     case CogApi.HTTP.Users.create(endpoint, params) do
       {:ok, user} ->
         username = user.username

--- a/lib/cogctl/actions/users/delete.ex
+++ b/lib/cogctl/actions/users/delete.ex
@@ -2,7 +2,7 @@ defmodule Cogctl.Actions.Users.Delete do
   use Cogctl.Action, "users delete"
 
   def option_spec do
-    [{:user, :undefined, :undefined, {:string, :undefined}, 'Username'}]
+    [{:user, :undefined, :undefined, :string, 'Username (required)'}]
   end
 
   def run(options, _args, _config, endpoint) do

--- a/lib/cogctl/actions/users/info.ex
+++ b/lib/cogctl/actions/users/info.ex
@@ -3,20 +3,14 @@ defmodule Cogctl.Actions.Users.Info do
   import Cogctl.Actions.Users.Util
 
   def option_spec do
-    [{:user, :undefined, :undefined, {:string, :undefined}, 'User username (required)'},
+    [{:user, :undefined, :undefined, :string, 'User username (required)'},
      {:groups, :undefined, 'groups', {:boolean, false}, 'Flag to display groups (default false)'},
      {:roles, :undefined, 'roles', {:boolean, false}, 'Flag to display roles (default false)'}]
   end
 
   def run(options, _args, _config, endpoint) do
-    case convert_to_params(options, option_spec, [user: :required,
-                                                  groups: :optional,
-                                                  roles: :optional]) do
-      {:ok, params} ->
-        with_authentication(endpoint, &do_info(&1, params))
-      {:error, {:missing_params, missing_args}} ->
-        display_arguments_error(missing_args)
-    end
+    params = convert_to_params(options)
+    with_authentication(endpoint, &do_info(&1, params))
   end
 
   defp do_info(endpoint, params) do

--- a/lib/cogctl/actions/users/update.ex
+++ b/lib/cogctl/actions/users/update.ex
@@ -3,7 +3,7 @@ defmodule Cogctl.Actions.Users.Update do
   alias Cogctl.Table
 
   def option_spec do
-    [{:user, :undefined, :undefined, {:string, :undefined}, 'Username (required)'},
+    [{:user, :undefined, :undefined, :string, 'Username (required)'},
      {:first_name, :undefined, 'first-name', {:string, :undefined}, 'First name'},
      {:last_name, :undefined, 'last-name', {:string, :undefined}, 'Last name'},
      {:email_address, :undefined, 'email', {:string, :undefined}, 'Email address'},
@@ -12,21 +12,13 @@ defmodule Cogctl.Actions.Users.Update do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options, [first_name: :optional,
-                                         last_name: :optional,
-                                         email_address: :optional,
-                                         username: :optional,
-                                         password: :optional])
+    params = convert_to_params(options)
 
     with_authentication(endpoint,
                         &do_update(&1, :proplists.get_value(:user, options), params))
   end
 
-  defp do_update(_endpoint, _user_username, {:error, {:missing_params, missing_params}}) do
-    display_arguments_error(missing_params)
-  end
-
-  defp do_update(endpoint, user_username, {:ok, params}) do
+  defp do_update(endpoint, user_username, params) do
     case CogApi.HTTP.Internal.user_update(endpoint, user_username, %{user: params}) do
       {:ok, resp} ->
         user = resp["user"]

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Cogctl.Mixfile do
     [
       # We override here because of a conflict in rebar. Spanner brings in emqtt which includes
       # rebar as a dep.
-      {:getopt, github: "jcomellas/getopt", tag: "v0.8.2", override: true},
+      {:getopt, github: "operable/getopt"},
       {:ibrowse, "~> 4.2.2"},
       {:httpotion, "~> 2.1.0"},
       # We override poison here because spanner is set to 1.5.2 due to phoenix requirements

--- a/mix.lock
+++ b/mix.lock
@@ -2,7 +2,7 @@
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "ex_json_schema": {:hex, :ex_json_schema, "0.3.1"},
-  "getopt": {:git, "https://github.com/jcomellas/getopt.git", "388dc95caa7fb97ec7db8cfc39246a36aba61bd8", [tag: "v0.8.2"]},
+  "getopt": {:git, "https://github.com/operable/getopt.git", "6014121002e3e34e8064486d4b34aedaa887f1c4", []},
   "httpotion": {:hex, :httpotion, "2.1.0"},
   "ibrowse": {:hex, :ibrowse, "4.2.2"},
   "piper": {:git, "https://github.com/operable/piper.git", "4f00f9433f999740984a27b366f53a8f46a43b03", []},

--- a/test/cogctl/action_util_test.exs
+++ b/test/cogctl/action_util_test.exs
@@ -3,16 +3,6 @@ defmodule Cogctl.ActionUtilTest do
 
   alias Cogctl.ActionUtil
 
-  test "converting valid options to params" do
-    params = ActionUtil.convert_to_params([a: :undefined, b: true, c: false], [b: :required, c: :optional])
-    assert params == {:ok, %{b: true, c: false}}
-  end
-
-  test "converting missing required options to params" do
-    params = ActionUtil.convert_to_params([a: true, b: :undefined, c: false], [b: :required, c: :optional])
-    assert params == {:error, {:missing_params, [:b]}}
-  end
-
   test "with_authentication runs function when authentication succeeds" do
     defmodule AuthEveryone do
       def authenticate(client),

--- a/test/cogctl/optparse_test.exs
+++ b/test/cogctl/optparse_test.exs
@@ -1,0 +1,76 @@
+defmodule Cogctl.OptParse.Test do
+  use ExUnit.Case, async: true
+
+  import ExUnit.CaptureIO
+  import ExUnit.Assertions
+
+  alias Cogctl.Optparse
+
+  @standard_options [:help,
+                     :host,
+                     :port,
+                     :secure,
+                     :rest_user,
+                     :rest_password,
+                     :profile]
+
+  defp parse(str) do
+    String.split(str)
+    |> Optparse.parse
+  end
+
+  # Gobles up the results of parse, use ExUnit.Assertions.assert_received/1
+  # if you want to verify the return of parse/1
+  defp capture_parse(str, device \\ :stderr) do
+    capture_io(device, fn ->
+      send(self(), parse(str))
+    end)
+  end
+
+  test "returns usage when no command is passed" do
+    assert capture_parse("") =~ ~r(Usage: cogctl\t\[.*)
+  end
+
+  test "parses commands with no options" do
+    {handler, options, args} = parse("bundles")
+    {_, options} = Keyword.split(options, @standard_options)
+
+    assert handler == Cogctl.Actions.Bundles
+    assert options == []
+    assert args == []
+  end
+
+  test "parses commands with options" do
+    {handler, options, args} = parse("bundles create my_config.yaml --templates my_templates --enable")
+    {_, options} = Keyword.split(options, @standard_options)
+
+    assert handler == Cogctl.Actions.Bundles.Create
+    assert options == [file: "my_config.yaml", templates: "my_templates", enabled: true, "relay-groups": []]
+    assert args == []
+  end
+
+  test "fails when required args aren't passed" do
+    # We test to see if "bundles create" prints usage info
+    assert capture_parse("bundles create") =~ ~r(Usage: .*)
+    # Then we check to see if it returns the correct value
+    assert_received {:error, "Missing required arguments: 'file'"}
+  end
+
+  test "lists are returned as elixir lists" do
+    {handler, options, args} = parse("relay-groups create foo --members bar,biz,baz")
+    {_, options} = Keyword.split(options, @standard_options)
+
+    assert handler == Cogctl.Actions.RelayGroups.Create
+    assert options == [name: "foo", members: ["bar", "biz", "baz"]]
+    assert args == []
+  end
+
+  test "extra args are returned" do
+    {handler, options, args} = parse("bundles delete foo biz baz buz")
+    {_, options} = Keyword.split(options, @standard_options)
+
+    assert handler == Cogctl.Actions.Bundles.Delete
+    assert options == []
+    assert args == ["foo", "biz", "baz", "buz"]
+  end
+end

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -71,9 +71,7 @@ defmodule CogctlTest do
     operable  enabled  .*
     """
 
-    assert run("cogctl bundles info") =~ ~r"""
-    ERROR: "Missing required arguments"
-    """
+    assert run("cogctl bundles info") =~ ~r(.*cogctl: Missing required arguments: 'bundle')
 
     assert run("cogctl bundles info operable") =~ ~r"""
     ID         .*

--- a/test/support/cli_case.ex
+++ b/test/support/cli_case.ex
@@ -32,6 +32,12 @@ defmodule Support.CliCase do
     raise ~s(Commands must start with "cogctl")
   end
 
+  def run_no_capture("cogctl" <> args) do
+    args
+    |> String.split
+    |> Cogctl.main
+  end
+
   defp smart_split([], acc), do: acc
   defp smart_split([head|tail], acc) do
     {start, sub} = check?(head)


### PR DESCRIPTION
`option_spec` now supports required options and a new type `list`. Lists are pretty rudimentary right now, they just split the string on ",". Also, since I was there, I went ahead and added short flags for things. Seemed like something we would want.

A lot of files were modified with this PR because it changes how we define options. The bulk of the actual work lives in `Cogctl.Optparse`

Resolves https://github.com/operable/cog/issues/578