### PR TITLE
Restructure the rendering of the Permissions and Chat-Handle resources

### DIFF
--- a/lib/cogctl/actions/chat_handles.ex
+++ b/lib/cogctl/actions/chat_handles.ex
@@ -1,6 +1,6 @@
 defmodule Cogctl.Actions.ChatHandles do
   use Cogctl.Action, "chat-handles"
-  alias Cogctl.Table
+  alias Cogctl.Actions.ChatHandles.View, as: ChatHandleView
 
   def option_spec do
     []
@@ -13,11 +13,8 @@ defmodule Cogctl.Actions.ChatHandles do
     case CogApi.HTTP.Internal.chat_handle_index(endpoint) do
       {:ok, resp} ->
         chat_handles = resp["chat_handles"]
-        chat_handle_attrs = for chat_handle <- chat_handles do
-          [chat_handle["user"]["username"], chat_handle["chat_provider"]["name"], chat_handle["handle"]]
-        end
+        ChatHandleView.render(chat_handles)
 
-        display_output(Table.format([["USER", "CHAT PROVIDER", "HANDLE"]] ++ chat_handle_attrs, true))
       {:error, error} ->
         display_error(error["errors"])
     end

--- a/lib/cogctl/actions/chat_handles/create.ex
+++ b/lib/cogctl/actions/chat_handles/create.ex
@@ -1,6 +1,6 @@
 defmodule Cogctl.Actions.ChatHandles.Create do
   use Cogctl.Action, "chat-handles create"
-  alias Cogctl.Table
+  alias Cogctl.Actions.ChatHandles.View, as: ChatHandleView
 
   def option_spec do
     [{:user, :undefined, 'user', {:string, :undefined}, 'Username of user to add handle to (required)'},
@@ -23,16 +23,7 @@ defmodule Cogctl.Actions.ChatHandles.Create do
     case CogApi.HTTP.Internal.chat_handle_create(endpoint, %{chat_handle: params}) do
       {:ok, resp} ->
         chat_handle = resp["chat_handle"]
-        user = chat_handle["user"]["username"]
-        chat_provider = chat_handle["chat_provider"]["name"]
-
-        chat_handle = Map.merge(chat_handle, %{"user" => user, "chat_provider" => chat_provider})
-
-        chat_handle_attrs = for {title, attr} <- [{"ID", "id"}, {"User", "user"}, {"Chat Provider", "chat_provider"}, {"Handle", "handle"}] do
-          [title, chat_handle[attr]]
-        end
-
-        Table.format(chat_handle_attrs, false) |> display_output
+        ChatHandleView.render(chat_handle)
       {:error, error} ->
         display_error(error["errors"])
     end

--- a/lib/cogctl/actions/chat_handles/view.ex
+++ b/lib/cogctl/actions/chat_handles/view.ex
@@ -1,0 +1,45 @@
+defmodule Cogctl.Actions.ChatHandles.View do
+  alias Cogctl.Table
+  import Cogctl.ActionUtil , only: [display_output: 1]
+
+  def render(chat_handles) when is_list(chat_handles) do
+    format_table(chat_handles)
+    |> Table.format(true)
+    |> display_output
+  end
+  def render(handle) do
+    handle_info = format_table(handle)
+
+    Table.format(handle_info, false)
+    |> display_output
+  end
+
+  def render_resource(nil), do: []
+  def render_resource(handles) do
+    chat_handles = Enum.map(handles, fn(handle) ->
+      get_in(handle, ["chat_provider", "name"]) <> ":" <> Map.get(handle, "handle")
+    end)
+    |> Enum.sort
+    |> Enum.join(", ")
+
+    [["Chat-handles", chat_handles]]
+  end
+
+  defp format_table(chat_handles) when is_list(chat_handles) do
+    rows = Enum.map(chat_handles, fn(chat_handle) ->
+      [get_in(chat_handle, ["user", "username"]),
+       get_in(chat_handle, ["chat_provider", "name"]),
+       Map.get(chat_handle, "handle")]
+    end)
+    [["USER", "CHAT PROVIDER", "HANDLE"]] ++ rows
+  end
+  defp format_table(handle) do
+    [
+      ["ID",            Map.get(handle, "id")],
+      ["User",          get_in(handle, ["user", "username"])],
+      ["Chat Provider", get_in(handle, ["chat_provider", "name"])],
+      ["Handle",        Map.get(handle, "handle")]
+    ]
+  end
+
+end

--- a/lib/cogctl/actions/permissions.ex
+++ b/lib/cogctl/actions/permissions.ex
@@ -1,6 +1,6 @@
 defmodule Cogctl.Actions.Permissions do
   use Cogctl.Action, "permissions"
-  alias Cogctl.Table
+  alias Cogctl.Actions.Permissions.View, as: PermissionView
 
   def option_spec do
     [{:role, :undefined, 'role', {:string, :undefined}, 'Name of role to filter permissions by'}]
@@ -19,11 +19,7 @@ defmodule Cogctl.Actions.Permissions do
     case CogApi.HTTP.Internal.permission_index(endpoint, params) do
       {:ok, resp} ->
         permissions = resp["permissions"]
-        permission_attrs = Enum.map(permissions, fn(permission) ->
-                               [permission["namespace"], permission["name"], permission["id"]]
-                           end)
-
-        display_output(Table.format([["NAMESPACE", "NAME", "ID"]] ++ permission_attrs, true))
+        PermissionView.render(permissions)
       {:error, error} ->
         display_error(error["errors"])
     end

--- a/lib/cogctl/actions/permissions/view.ex
+++ b/lib/cogctl/actions/permissions/view.ex
@@ -2,12 +2,34 @@ defmodule Cogctl.Actions.Permissions.View do
   alias Cogctl.Table
   import Cogctl.ActionUtil , only: [display_output: 1]
 
+  def render(permissions) when is_list(permissions) do
+    format_table(permissions)
+    |> Table.format(true)
+    |> display_output
+  end
   def render(permission) do
     format_table(permission)
     |> Table.format(false)
     |> display_output
   end
 
+  def render_resource(nil), do: []
+  def render_resource(permissions) do
+    permission_names = Enum.map(permissions, &(&1.namespace <> ":" <> &1.name))
+    |> Enum.sort
+    |> Enum.join(",")
+
+    [["Permissions", permission_names]]
+  end
+
+  defp format_table(permisssions) when is_list(permisssions) do
+    rows = Enum.map(permisssions, fn(permission) ->
+      [permission["namespace"],
+       permission["name"],
+       permission["id"]]
+    end)
+    [["NAMESPACE", "NAME", "ID"]] ++ rows
+  end
   defp format_table(permission) do
     [
       ["ID",    permission.id],

--- a/lib/cogctl/actions/permissions/view.ex
+++ b/lib/cogctl/actions/permissions/view.ex
@@ -22,13 +22,8 @@ defmodule Cogctl.Actions.Permissions.View do
     [["Permissions", permission_names]]
   end
 
-  defp format_table(permisssions) when is_list(permisssions) do
-    rows = Enum.map(permisssions, fn(permission) ->
-      [permission["namespace"],
-       permission["name"],
-       permission["id"]]
-    end)
-    [["NAMESPACE", "NAME", "ID"]] ++ rows
+  defp format_table(permissions) when is_list(permissions) do
+    [["NAMESPACE", "NAME", "ID"] | Enum.map(permissions, &([&1["namespace"], &1["name"], &1["id"]]))]
   end
   defp format_table(permission) do
     [


### PR DESCRIPTION
This restructuring allows us to retrieve a permissions or chat-handle resource and render the output in a separate function. This way we can easily read and maintain how this information is displayed. It also allows for consistency in how the data is displayed.

Connected to https://github.com/operable/cog/issues/580