### PR TITLE
Use the HTTP status code to determine success for bootstrapping

### DIFF
--- a/lib/cogctl/actions/bootstrap.ex
+++ b/lib/cogctl/actions/bootstrap.ex
@@ -32,8 +32,8 @@ defmodule Cogctl.Actions.Bootstrap do
   end
 
   defp do_bootstrap(endpoint, config) do
-    case CogApi.HTTP.Internal.bootstrap_create(endpoint) do
-      {:ok, admin} ->
+    case CogApi.HTTP.Internal.bootstrap_create(endpoint, status_code: true) do
+      {200, admin} ->
         values = config.values
                  |> Map.put(endpoint.host, %{"user" => get_in(admin, ["bootstrap", "username"]),
                                            "password" => get_in(admin, ["bootstrap", "password"]),
@@ -43,9 +43,9 @@ defmodule Cogctl.Actions.Bootstrap do
         config = %{config | dirty: true, values: values}
         Cogctl.Config.save(config)
         display_output("Bootstrapped")
-      {:error, %{"errors" => %{"bootstrap" => error}}} ->
-        display_error(error)
-      {:error, %{"errors" => error}} ->
+      {423, _} ->
+        display_output("Already bootstrapped")
+      {_, %{"errors" => error}} ->
         display_error(error)
     end
   end

--- a/lib/cogctl/actions/bundles/create.ex
+++ b/lib/cogctl/actions/bundles/create.ex
@@ -63,7 +63,7 @@ defmodule Cogctl.Actions.Bundles.Create do
         end
 
         commands = for command <- bundle.commands do
-          [command["name"], command["id"]]
+          [command.name, command.id]
         end
 
         display_output("""

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Cogctl.Mixfile do
       # We override poison here because spanner is set to 1.5.2 due to phoenix requirements
       {:poison, "~> 2.0", override: true},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client", branch: "peck/optional-status-code-return"},
+      {:cog_api, github: "operable/cog-api-client"},
       {:spanner, github: "operable/spanner"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Cogctl.Mixfile do
       # We override poison here because spanner is set to 1.5.2 due to phoenix requirements
       {:poison, "~> 2.0", override: true},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client", branch: "peck/optional/status-code-return"},
+      {:cog_api, github: "operable/cog-api-client", branch: "peck/optional-status-code-return"},
       {:spanner, github: "operable/spanner"}
     ]
   end

--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule Cogctl.Mixfile do
       # We override poison here because spanner is set to 1.5.2 due to phoenix requirements
       {:poison, "~> 2.0", override: true},
       {:configparser_ex, "~> 0.2.0"},
-      {:cog_api, github: "operable/cog-api-client"},
+      {:cog_api, github: "operable/cog-api-client", branch: "peck/optional/status-code-return"},
       {:spanner, github: "operable/spanner"}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "a099264d22120ebbb15a29ed7a1ef2c94f0d3ae8", []},
+%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "c91690b1b393640607591565c559fa0d8e539a16", []},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "ex_json_schema": {:hex, :ex_json_schema, "0.3.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "c91690b1b393640607591565c559fa0d8e539a16", []},
+%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "c91690b1b393640607591565c559fa0d8e539a16", [branch: "peck/optional/status-code-return"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "ex_json_schema": {:hex, :ex_json_schema, "0.3.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "3141babe1d77ab1b691e284617ce431faf973463", [branch: "peck/optional-status-code-return"]},
+%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "eee4226a710fe510f441983dd0c3d63f5f705925", []},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "ex_json_schema": {:hex, :ex_json_schema, "0.3.1"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,4 +1,4 @@
-%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "c91690b1b393640607591565c559fa0d8e539a16", [branch: "peck/optional/status-code-return"]},
+%{"cog_api": {:git, "https://github.com/operable/cog-api-client.git", "3141babe1d77ab1b691e284617ce431faf973463", [branch: "peck/optional-status-code-return"]},
   "configparser_ex": {:hex, :configparser_ex, "0.2.0"},
   "dialyxir": {:hex, :dialyxir, "0.3.3"},
   "ex_json_schema": {:hex, :ex_json_schema, "0.3.1"},

--- a/test/support/cli_case.ex
+++ b/test/support/cli_case.ex
@@ -67,7 +67,7 @@ defmodule Support.CliCase do
 
   defp ensure_started do
     case run("cogctl bootstrap") do
-      "ERROR: \"Already bootstrapped\"\n" ->
+      "Already bootstrapped\n" ->
         :ok
       "Bootstrapped\n" ->
         :ok


### PR DESCRIPTION
When you bootstrap a system that is already bootstrapped you get a 423 back, which is technically an error. This would cause cogctl to exit with a status of 1. We want bootstrapping to be idempotent, so now if we get a 423, we just let the user know that the system is already bootstrapped and exit with a 0.

 - [x] depends on https://github.com/operable/cog-api-client/pull/119
 - [ ] resolves https://github.com/operable/cog/issues/574