### PR TITLE
return a proper error to the user when an invalid option is passed

### DIFF
--- a/lib/cogctl/optparse.ex
+++ b/lib/cogctl/optparse.ex
@@ -91,6 +91,9 @@ defmodule Cogctl.Optparse do
         {:error, {:missing_required_options, missing}} ->
           show_usage(handler, :stderr)
           {:error, "Missing required arguments: '#{Enum.join(missing, ", ")}'"}
+        {:error, {:invalid_option, invalid_option_name}} ->
+          show_usage(handler, :stderr)
+          {:error, "Unknown option: '#{invalid_option_name}'"}
         {options, remaining_args} ->
           {handler, options, remaining_args}
         error ->

--- a/test/cogctl/optparse_test.exs
+++ b/test/cogctl/optparse_test.exs
@@ -73,4 +73,9 @@ defmodule Cogctl.OptParse.Test do
     assert options == []
     assert args == ["foo", "biz", "baz", "buz"]
   end
+
+  test "exit gracefully when invalid options are passed" do
+    assert capture_parse("relays create --bar") =~ ~r(Usage: .*)
+    assert_received {:error, "Unknown option: '--bar'"}
+  end
 end


### PR DESCRIPTION
Instead of crashing when a user passes an invalid arg, we should return an error to the user and exit gracefully.

resolves https://github.com/operable/cog/issues/634