### PR TITLE
add 'cogctl:' to error output

### DIFF
--- a/lib/cogctl.ex
+++ b/lib/cogctl.ex
@@ -95,8 +95,7 @@ defmodule Cogctl do
   defp load_profile(name, config) do
     case Map.get(config.values, name) do
       nil ->
-        IO.puts "Profile '#{name}' is missing."
-        exit({:shutdown, 1})
+        exit_with_error("ERROR: Profile '#{name}' is missing.")
       profile ->
         build_profile(profile)
     end

--- a/lib/cogctl/action_util.ex
+++ b/lib/cogctl/action_util.ex
@@ -61,7 +61,7 @@ defmodule Cogctl.ActionUtil do
         fun.(endpoint_with_token)
       {:error, error} ->
         IO.puts(:stderr, """
-        Unable to authenticate with Cog API:
+        cogctl: Unable to authenticate with Cog API:
         #{format_error(error)}
 
         You can specify appropriate credentials on the command line via
@@ -79,20 +79,20 @@ defmodule Cogctl.ActionUtil do
   end
 
   def display_warning(warnings) when is_list(warnings) do
-    IO.puts(:stderr, Enum.map_join(warnings, "\n", &("WARNING: #{inspect &1}")))
+    IO.puts(:stderr, Enum.map_join(warnings, "\n", &("cogctl: WARNING: #{inspect &1}")))
     :ok
   end
   def display_warning(warning) do
-    IO.puts(:stderr, "WARNING: #{inspect warning}")
+    IO.puts(:stderr, "cogctl: WARNING: #{inspect warning}")
     :ok
   end
 
   def display_error(errors) when is_list(errors) do
-    IO.puts(:stderr, Enum.map_join(errors, "\n", &("ERROR: #{inspect &1}")))
+    IO.puts(:stderr, Enum.map_join(errors, "\n", &("cogctl: ERROR: #{inspect &1}")))
     :error
   end
   def display_error(error) do
-    IO.puts(:stderr, "ERROR: #{inspect error}")
+    IO.puts(:stderr, "cogctl: ERROR: #{inspect error}")
     :error
   end
 

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -373,7 +373,7 @@ defmodule CogctlTest do
 
   test "cogctl rules" do
     assert run("cogctl rules operable:test") =~ ~r"""
-    ERROR: "No rules for command found"
+    cogctl: ERROR: "No rules for command found"
     """
 
     # Set up the permission
@@ -492,7 +492,7 @@ defmodule CogctlTest do
 
     assert run("cogctl relays delete test-relay mimimi") =~ ~r"""
     Deleted 'test-relay'
-    ERROR: "The relay `mimimi` could not be deleted: Resource not found for: 'relays'"
+    cogctl: ERROR: "The relay `mimimi` could not be deleted: Resource not found for: 'relays'"
     """
 
     run("cogctl relay-groups create mygroup")


### PR DESCRIPTION
`cogctl:` now prefixes error messages. This should make it easier to spot errors from cogctl when it's in the middle of a pipeline.