### PR TITLE
cogctl crash on bad commands

### DIFF
--- a/lib/cogctl/optparse.ex
+++ b/lib/cogctl/optparse.ex
@@ -208,7 +208,7 @@ defmodule Cogctl.Optparse do
         {:ok, handler, remaining_args}
       :unknown_action ->
         suggestion = get_suggestion(handlers, args)
-        {:error, "Unknown action in '#{Enum.join(args, " ")}'. Did you mean '#{suggestion}'"}
+        {:error, "Unknown action in '#{Enum.join(args, " ")}'. Did you mean '#{suggestion}'?"}
     end
   end
 

--- a/lib/cogctl/optparse.ex
+++ b/lib/cogctl/optparse.ex
@@ -207,8 +207,15 @@ defmodule Cogctl.Optparse do
       {:ok, handler, remaining_args} ->
         {:ok, handler, remaining_args}
       :unknown_action ->
-        {:error, "Unknown action '#{hd(args)}' in '#{Enum.join(args, " ")}'"}
+        suggestion = get_suggestion(handlers, args)
+        {:error, "Unknown action in '#{Enum.join(args, " ")}'. Did you mean '#{suggestion}'"}
     end
+  end
+
+  defp get_suggestion(handlers, args) do
+    action = Enum.join(args, " ")
+    Enum.map(handlers, &Enum.join(Map.get(&1, :pattern), " "))
+    |> Enum.max_by(&String.jaro_distance(&1, action))
   end
 
   defp handler_patterns() do

--- a/lib/cogctl/optparse.ex
+++ b/lib/cogctl/optparse.ex
@@ -83,7 +83,7 @@ defmodule Cogctl.Optparse do
     parse(:help)
   end
   def parse(action_str) when length(action_str) > 0 do
-    with {handler, args} <- parse_action(action_str) do
+    with {:ok, handler, args} <- parse_action(action_str) do
       case parse_args(handler, args) do
         :help ->
           show_usage(handler)
@@ -205,7 +205,7 @@ defmodule Cogctl.Optparse do
 
     case result do
       {:ok, handler, remaining_args} ->
-        {handler, remaining_args}
+        {:ok, handler, remaining_args}
       :unknown_action ->
         {:error, "Unknown action '#{hd(args)}' in '#{Enum.join(args, " ")}'"}
     end

--- a/test/cogctl/optparse_test.exs
+++ b/test/cogctl/optparse_test.exs
@@ -78,4 +78,8 @@ defmodule Cogctl.OptParse.Test do
     assert capture_parse("relays create --bar") =~ ~r(Usage: .*)
     assert_received {:error, "ERROR: Unknown option: '--bar'"}
   end
+
+  test "exit with a suggestion when an unknown command is passed" do
+    assert parse("boostrap") == {:error, "Unknown action in 'boostrap'. Did you mean 'bootstrap'"}
+  end
 end

--- a/test/cogctl/optparse_test.exs
+++ b/test/cogctl/optparse_test.exs
@@ -80,6 +80,6 @@ defmodule Cogctl.OptParse.Test do
   end
 
   test "exit with a suggestion when an unknown command is passed" do
-    assert parse("boostrap") == {:error, "Unknown action in 'boostrap'. Did you mean 'bootstrap'"}
+    assert parse("boostrap") == {:error, "Unknown action in 'boostrap'. Did you mean 'bootstrap'?"}
   end
 end


### PR DESCRIPTION
Don't crash when a user passes a misspelled command. Instead give them a better suggestion.

resolves https://github.com/operable/cog/issues/685