### PR TITLE
Add an option to tell cogctl to read from stdin

### DIFF
--- a/lib/cogctl/optparse.ex
+++ b/lib/cogctl/optparse.ex
@@ -122,19 +122,15 @@ defmodule Cogctl.Optparse do
     end
   end
 
-  defp maybe_read_from_stdin(options, specs, args) do
-    if :proplists.get_value(:stdin, options) do
-      stdin = read_from_stdin()
-      :getopt.parse(specs, args ++ stdin)
-    else
-      {:ok, {options, args}}
-    end
-  end
-
   defp parse_args(handler, args) do
     specs = opt_specs(handler)
-    result = with {:ok, {options, _}} <- :getopt.parse(specs, args) do
-      maybe_read_from_stdin(options, specs, args)
+    result = with {:ok, {options, remaining}} <- :getopt.parse(specs, args) do
+      if :proplists.get_value(:stdin, options) do
+        stdin = read_from_stdin()
+        :getopt.parse(specs, args ++ stdin)
+      else
+        {:ok, {options, remaining}}
+      end
     end
 
     case result do

--- a/test/cogctl/optparse_test.exs
+++ b/test/cogctl/optparse_test.exs
@@ -8,6 +8,7 @@ defmodule Cogctl.OptParse.Test do
 
   @standard_options [:help,
                      :host,
+                     :stdin,
                      :port,
                      :secure,
                      :rest_user,


### PR DESCRIPTION
This adds an option for cogctl to read from stdin, `[-i | --stdin]`.

Now you can do things like `curl http://some.fancy.url | cogctl bundle install -i`