### PR TITLE
allow config file location to be specified

### DIFF
--- a/lib/cogctl.ex
+++ b/lib/cogctl.ex
@@ -17,7 +17,7 @@ defmodule Cogctl do
     Application.start(:ibrowse)
 
     result = with {handler, options, remaining} <- Cogctl.Optparse.parse(args),
-      {:ok, config} <- Cogctl.Config.load,
+      {:ok, config} <- Cogctl.Config.load(options),
       {:ok, identity} <- configure_identity(options, config),
       do: handler.run(options, remaining, config, identity)
 

--- a/lib/cogctl/actions/rules.ex
+++ b/lib/cogctl/actions/rules.ex
@@ -20,7 +20,7 @@ defmodule Cogctl.Actions.Rules do
       {:ok, resp} ->
         rules = resp["rules"]
         rule_attrs = for rule <- rules do
-          [rule["id"], rule["command"], rule["rule"]]
+          [rule["id"], rule["command_name"], rule["rule"]]
         end
 
         display_output(Table.format([["ID", "COMMAND", "RULE TEXT"]] ++ rule_attrs, true))

--- a/lib/cogctl/optparse.ex
+++ b/lib/cogctl/optparse.ex
@@ -261,7 +261,8 @@ defmodule Cogctl.Optparse do
      {:rest_user, ?U, 'rest-user', {:string, :undefined}, 'REST API user'},
      {:rest_password, ?P, 'rest-password', {:string, :undefined}, 'REST API password'},
      {:stdin, ?i, 'stdin', {:boolean, :false}, 'Read from stdin'},
-     {:profile, :undefined, 'profile', {:string, :undefined}, '$HOME/.cogctl profile to use'}]
+     {:config_file, :undefined, 'config-file', {:string, Cogctl.Config.default_config_file}, 'Path to configuration file to use'},
+     {:profile, :undefined, 'profile', {:string, :undefined}, 'Profile from configuration file to use'}]
   end
 
   defp ensure_elixir_strings(items) do

--- a/test/cogctl/optparse_test.exs
+++ b/test/cogctl/optparse_test.exs
@@ -13,7 +13,10 @@ defmodule Cogctl.OptParse.Test do
                      :secure,
                      :rest_user,
                      :rest_password,
+                     :config_file,
                      :profile]
+
+  @default_options [config_file: Cogctl.Config.default_config_file]
 
   defp parse(str) do
     String.split(str)
@@ -38,6 +41,30 @@ defmodule Cogctl.OptParse.Test do
 
     assert handler == Cogctl.Actions.RelayGroups
     assert options == []
+    assert args == []
+  end
+
+  test "config_file defaults to ~/.cogctl" do
+    System.delete_env("COGCTL_CONFIG_FILE")
+    {handler, options, args} = parse("relay-groups")
+    config_file = :proplists.get_value(:config_file, options)
+    {_, split_options} = :proplists.split(options, @standard_options)
+
+    assert config_file == Cogctl.Config.default_config_file
+    assert handler == Cogctl.Actions.RelayGroups
+    assert split_options == []
+    assert args == []
+  end
+
+  test "config_file defaults to $COGCTL_CONFIG_FILE if set" do
+    System.put_env("COGCTL_CONFIG_FILE", "/home/operable/cogctl.conf")
+    {handler, options, args} = parse("relay-groups")
+    config_file = :proplists.get_value(:config_file, options)
+    {_, split_options} = :proplists.split(options, @standard_options)
+
+    assert config_file == "/home/operable/cogctl.conf"
+    assert handler == Cogctl.Actions.RelayGroups
+    assert split_options == []
     assert args == []
   end
 


### PR DESCRIPTION
## Summary

* Adds an optional `--config-file` option. If present, this path takes precedence as configuration file location over all other settings.
* Allows a `$COGCTL_CONFIG_FILE` environment variable to be set. If present, this location will be used as the default configuration file path instead of `~/.cogctl`. As stated above, if the `--config-file` option always wins if it is also passed, whether or not the `$COGCTL_CONFIG_FILE` variable is set.
* In the absence of a `--config-file` option or a `$COGCTL_CONFIG_FILE` environment variable, continue to use `~/.cogctl` as the default configuration file.

## Examples

### Option Example

This adds a `--config-file` option whose value will be used as the filename for all configuration file operations.

```
>> imbriaco @ trogdor [ ~/operable/cogctl (imbriaco/config-file-path *) ]
 $ mv ~/.cogctl ~/.cogctl.bak

>> imbriaco @ trogdor [ ~/operable/cogctl (imbriaco/config-file-path *) ]
 $ ./cogctl bootstrap --config-file ~/my-cog-config.conf
Bootstrapped

>> imbriaco @ trogdor [ ~/operable/cogctl (imbriaco/config-file-path *) ]
 $ cat ~/.cogctl
cat: /Users/imbriaco/.cogctl: No such file or directory

>> imbriaco @ trogdor [ ~/operable/cogctl (imbriaco/config-file-path *) ]
 $ cat ~/my-cog-config.conf
[defaults]
profile=localhost

[localhost]
host=localhost
password=...
port=4000
secure=false
user=admin

>> imbriaco @ trogdor [ ~/operable/cogctl (imbriaco/config-file-path *) ]
 $ ./cogctl users --config-file ~/my-cog-config.conf
USERNAME  FULL NAME          EMAIL_ADDRESS
admin     Cog Administrator  cog@localhost

>> imbriaco @ trogdor [ ~/operable/cogctl (imbriaco/config-file-path *) ]
 $ cogctl users
** (CaseClauseError) no case clause matching: {:authentication_error, ["Must supply both a username and password"]}
    (cogctl) lib/cogctl/action_util.ex:59: Cogctl.ActionUtil.with_authentication/3
    (cogctl) lib/cogctl.ex:22: Cogctl.main/1
    (elixir) lib/kernel/cli.ex:76: anonymous fn/3 in Kernel.CLI.exec_fun/2
```
### Environment Example

The default behavior for cogctl is to use `~/.cogctl` as the base filename for all 
configuration file operations unless there's a `COGCTL_CONFIG_FILE` environment 
variable set. If that variable is set, the referenced path will be used as the default base 
filename instead.

This will be super handy for Docker. If we mount a single data volume, we can
configure Cog to write logs there as well as persist a configuration file that
will be used for `cogctl` runs from inside the Cog container.

```
>> imbriaco @ trogdor [ ~/operable/cogctl (imbriaco/config-file-path *) ]
 $ export COGCTL_CONFIG_FILE=~/my-cog-config.conf

>> imbriaco @ trogdor [ ~/operable/cogctl (imbriaco/config-file-path *) ]
 $ cogctl users
USERNAME  FULL NAME          EMAIL_ADDRESS
admin     Cog Administrator  cog@localhost

>> imbriaco @ trogdor [ ~/operable/cogctl (imbriaco/config-file-path *) ]
 $ cogctl users --config-file ~/.cogctl-zomg
USERNAME  FULL NAME          EMAIL_ADDRESS
admin     Cog Administrator  cog@localhost
```

### Default Example (No `--config-file`, no ENV var)

The default is still to use the normal `~/.cogctl` file.

```
>> imbriaco @ trogdor [ ~/operable/cogctl (imbriaco/config-file-path *) ]
 $ cat ~/.cogctl
cat: /Users/imbriaco/.cogctl: No such file or directory

>> imbriaco @ trogdor [ ~/operable/cogctl (imbriaco/config-file-path *) ]
 $ ./cogctl bootstrap
Bootstrapped

>> imbriaco @ trogdor [ ~/operable/cogctl (imbriaco/config-file-path *) ]
 $ cat ~/.cogctl
[defaults]
profile=localhost

[localhost]
host=localhost
password=...
port=4000
secure=false
user=admin

>> imbriaco @ trogdor [ ~/operable/cogctl (imbriaco/config-file-path *) ]
 $ cogctl users
USERNAME  FULL NAME          EMAIL_ADDRESS
admin     Cog Administrator  cog@localhost

```

