### PR TITLE
start the :cog_api application 

### DIFF
--- a/lib/cogctl.ex
+++ b/lib/cogctl.ex
@@ -14,8 +14,6 @@ defmodule Cogctl do
   end
 
   def main(args) do
-    Application.start(:ibrowse)
-
     result = with {handler, options, remaining} <- Cogctl.Optparse.parse(args),
       {:ok, config} <- Cogctl.Config.load(options),
       {:ok, identity} <- configure_identity(options, config),

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Cogctl.Mixfile do
   end
 
   def application do
-    [applications: [:logger, :yaml_elixir]]
+    [applications: [:cog_api, :logger, :yaml_elixir]]
   end
 
   defp deps do


### PR DESCRIPTION
This application was not being started, which meant that its downstream dependencies were also not being started. This manifested as the `:ssl` application not running which prevented cogctl from talking to SSL based cog instances. 
