### PR TITLE
Whitelist params

### DIFF
--- a/lib/cogctl/action_util.ex
+++ b/lib/cogctl/action_util.ex
@@ -26,18 +26,10 @@ defmodule Cogctl.ActionUtil do
   end
 
   @doc """
-  Returns a map containing the key/value pairs of the
-  parameters for a command.
+  Strips out empty options and anything not present in the whitelist and
+  returns a map containing the key/value pairs of the parameters for a command.
   """
-  @spec convert_to_params([{atom(), any()}]) :: Map.t
-  def convert_to_params(options) do
-    whitelist = options
-    |> Keyword.keys
-    |> Enum.uniq
-
-    convert_to_params(options, whitelist)
-  end
-
+  @spec convert_to_params([{atom(), any()}], [atom()]) :: Map.t
   def convert_to_params(options, whitelist) do
     options
     |> Enum.reject(&(elem(&1, 1) in [nil, :undefined, ""]))

--- a/lib/cogctl/action_util.ex
+++ b/lib/cogctl/action_util.ex
@@ -31,12 +31,17 @@ defmodule Cogctl.ActionUtil do
   """
   @spec convert_to_params([{atom(), any()}]) :: Map.t
   def convert_to_params(options) do
-    Enum.reject(options, fn
-      ({_, nil}) -> true
-      ({_, :undefined}) -> true
-      ({_, ""}) -> true
-      (_) -> false
-    end)
+    whitelist = options
+    |> Keyword.keys
+    |> Enum.uniq
+
+    convert_to_params(options, whitelist)
+  end
+
+  def convert_to_params(options, whitelist) do
+    options
+    |> Enum.reject(&(elem(&1, 1) in [nil, :undefined, ""]))
+    |> Enum.filter(&(elem(&1, 0) in whitelist))
     |> Enum.into(%{})
   end
 

--- a/lib/cogctl/actions/bundle/install.ex
+++ b/lib/cogctl/actions/bundle/install.ex
@@ -36,7 +36,7 @@ defmodule Cogctl.Actions.Bundle.Install do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:file, :templates, :enabled, :verbose, :"relay-groups"])
     with_authentication(endpoint, &do_install(&1, params))
   end
 

--- a/lib/cogctl/actions/chat_handles/create.ex
+++ b/lib/cogctl/actions/chat_handles/create.ex
@@ -9,7 +9,7 @@ defmodule Cogctl.Actions.ChatHandles.Create do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:user, :chat_provider, :handle])
     with_authentication(endpoint, &do_create(&1, params))
   end
 

--- a/lib/cogctl/actions/chat_handles/delete.ex
+++ b/lib/cogctl/actions/chat_handles/delete.ex
@@ -7,7 +7,7 @@ defmodule Cogctl.Actions.ChatHandles.Delete do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:user, :chat_provider])
     with_authentication(endpoint, &do_delete(&1, params))
   end
 

--- a/lib/cogctl/actions/permissions.ex
+++ b/lib/cogctl/actions/permissions.ex
@@ -7,7 +7,7 @@ defmodule Cogctl.Actions.Permissions do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:role])
     with_authentication(endpoint, &do_list(&1, params))
   end
 

--- a/lib/cogctl/actions/relay_groups/add.ex
+++ b/lib/cogctl/actions/relay_groups/add.ex
@@ -15,7 +15,7 @@ defmodule Cogctl.Actions.RelayGroups.Add do
 
   def run(options, _args, _config, endpoint) do
     # At least one relay is required, so we specify that here
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:relay_group, :relays])
     with_authentication(endpoint, &do_add(&1, params))
   end
 

--- a/lib/cogctl/actions/relay_groups/assign.ex
+++ b/lib/cogctl/actions/relay_groups/assign.ex
@@ -17,7 +17,7 @@ defmodule Cogctl.Actions.RelayGroups.Assign do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:relay_group, :bundles])
     with_authentication(endpoint, &do_assign(&1, params))
   end
 

--- a/lib/cogctl/actions/relay_groups/create.ex
+++ b/lib/cogctl/actions/relay_groups/create.ex
@@ -11,7 +11,7 @@ defmodule Cogctl.Actions.RelayGroups.Create do
     with_authentication(endpoint, &run(options, nil, nil, &1))
   end
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:name, :members])
     do_create(endpoint, params)
   end
 

--- a/lib/cogctl/actions/relay_groups/remove.ex
+++ b/lib/cogctl/actions/relay_groups/remove.ex
@@ -14,7 +14,7 @@ defmodule Cogctl.Actions.RelayGroups.Remove do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:relay_group, :relays])
     with_authentication(endpoint, &do_remove(&1, params))
   end
 

--- a/lib/cogctl/actions/relay_groups/unassign.ex
+++ b/lib/cogctl/actions/relay_groups/unassign.ex
@@ -17,7 +17,7 @@ defmodule Cogctl.Actions.RelayGroups.Unassign do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:relay_group, :bundles])
     with_authentication(endpoint, &do_unassign(&1, params))
   end
 

--- a/lib/cogctl/actions/relays/create.ex
+++ b/lib/cogctl/actions/relays/create.ex
@@ -12,7 +12,7 @@ defmodule Cogctl.Actions.Relays.Create do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:name, :token, :enable, :description, :groups, :id])
     with_authentication(endpoint, &do_create(&1, params))
   end
 

--- a/lib/cogctl/actions/relays/update.ex
+++ b/lib/cogctl/actions/relays/update.ex
@@ -10,7 +10,7 @@ defmodule Cogctl.Actions.Relays.Update do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:relay, :name, :token, :description])
     with_authentication(endpoint, &do_update(&1, params))
   end
 

--- a/lib/cogctl/actions/roles/info.ex
+++ b/lib/cogctl/actions/roles/info.ex
@@ -9,7 +9,7 @@ defmodule Cogctl.Actions.Roles.Info do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:role, :permissions, :groups])
     with_authentication(endpoint, &do_info(&1, params))
   end
 

--- a/lib/cogctl/actions/roles/rename.ex
+++ b/lib/cogctl/actions/roles/rename.ex
@@ -8,7 +8,7 @@ defmodule Cogctl.Actions.Roles.Rename do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:role, :name])
     with_authentication(endpoint,
                         &do_rename(&1, :proplists.get_value(:role, options), params))
   end

--- a/lib/cogctl/actions/triggers/create.ex
+++ b/lib/cogctl/actions/triggers/create.ex
@@ -13,7 +13,7 @@ defmodule Cogctl.Actions.Triggers.Create do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:name, :pipeline, :enabled, :as_user, :timeout_sec, :description])
     with_authentication(endpoint, &do_create(&1, params))
   end
 

--- a/lib/cogctl/actions/triggers/update.ex
+++ b/lib/cogctl/actions/triggers/update.ex
@@ -15,10 +15,8 @@ defmodule Cogctl.Actions.Triggers.Update do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
-    name = :proplists.get_value(:trigger, options)
-
-    with_authentication(endpoint, &do_update(&1, name, params))
+    params = convert_to_params(options, [:trigger, :name, :pipeline, :enabled, :as_user, :timeout_sec, :description])
+    with_authentication(endpoint, &do_update(&1, params[:trigger], params))
   end
 
   defp do_update(endpoint, trigger_name, params) do

--- a/lib/cogctl/actions/users/create.ex
+++ b/lib/cogctl/actions/users/create.ex
@@ -14,8 +14,7 @@ defmodule Cogctl.Actions.Users.Create do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
-
+    params = convert_to_params(options, [:first_name, :last_name, :email_address, :username, :password])
     with_authentication(endpoint, &do_create(&1, params))
   end
 

--- a/lib/cogctl/actions/users/info.ex
+++ b/lib/cogctl/actions/users/info.ex
@@ -9,7 +9,7 @@ defmodule Cogctl.Actions.Users.Info do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
+    params = convert_to_params(options, [:user, :groups, :roles])
     with_authentication(endpoint, &do_info(&1, params))
   end
 

--- a/lib/cogctl/actions/users/update.ex
+++ b/lib/cogctl/actions/users/update.ex
@@ -12,10 +12,8 @@ defmodule Cogctl.Actions.Users.Update do
   end
 
   def run(options, _args, _config, endpoint) do
-    params = convert_to_params(options)
-
-    with_authentication(endpoint,
-                        &do_update(&1, :proplists.get_value(:user, options), params))
+    params = convert_to_params(options, [:user, :first_name, :last_name, :email_address, :username, :password])
+    with_authentication(endpoint, &do_update(&1, params[:user], params))
   end
 
   defp do_update(endpoint, user_username, params) do


### PR DESCRIPTION
We're now only sending params we expect down to the cog-api-client. Things like `config_path` are no longer sent in API requests.