### PR TITLE
Parameterize the cog server being built

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -17,7 +17,13 @@ else
 
   cd $COG_DIR
   git fetch origin
-  git reset --hard origin/master
+
+  # If this build is being triggered from a Cog build, then there
+  # should be a $COG_BRANCH variable set. If not, just use the master
+  # branch.
+  BRANCH=${COG_BRANCH:-master}
+  echo "Running cog from the ${BRANCH} branch"
+  git reset --hard origin/${BRANCH}
 fi
 
 mix do deps.get, ecto.create, ecto.migrate

--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -19,11 +19,21 @@ else
   git fetch origin
 
   # If this build is being triggered from a Cog build, then there
-  # should be a $COG_BRANCH variable set. If not, just use the master
-  # branch.
-  BRANCH=${COG_BRANCH:-master}
-  echo "Running cog from the ${BRANCH} branch"
-  git reset --hard origin/${BRANCH}
+  # should be a $COG_BRANCH variable set. If not, see if Cog has a
+  # branch named the same as what we're building. Othwerwise, just use
+  # the master branch.
+  if [ -z ${COG_BRANCH+notset} ]
+  then
+      if git ls-remote --exit-code --heads https://github.com/operable/cog refs/heads/${BUILDKITE_BRANCH} > /dev/null 2>&1
+      then
+          COG_BRANCH=${BUILDKITE_BRANCH}
+      else
+          COG_BRANCH='master'
+      fi
+  fi
+
+  echo "Running cog from the ${COG_BRANCH} branch"
+  git reset --hard origin/${COG_BRANCH}
 fi
 
 mix do deps.get, ecto.create, ecto.migrate


### PR DESCRIPTION
When we kick off a dependent cogctl build from a cog build, we'll want
to run against the version of cog that just built. In those cases, a
`COG_BRANCH` environment variable will be present which we can use.

Also, TIL: apparently Buildkite runs scripts with `set -u`

See operable/cog#1047

Fixes operable/cog#1035

UPDATE:

If a build is triggered from cog, the cogctl tests will run using whatever branch of cog just built. If the build is triggered from cogctl, we'll try to use a branch in cog that has the same name as what's building in cogctl. If no such branch exists, we'll build from the master branch of cog.