### PR TITLE
Properly run cog-triggered pipelines

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,36 +1,3 @@
 steps:
-  - command: "true"
-    label: ":docker: Build Test Image"
-    # Image compiles test code so it will be cached for other downstream tests
-    env:
-      BUILDKITE_DOCKER: true
-      BUILDKITE_DOCKER_FILE: Dockerfile.ci
-    agents:
-      - docker=1.12.1
-
-  - wait
-
-  - command: "mix escript"
-    label: ":elixir: Escript Build"
-    env:
-      MIX_ENV: prod
-      BUILDKITE_DOCKER: true
-      BUILDKITE_DOCKER_FILE: Dockerfile.ci
-    agents:
-      - docker=1.12.1
-
-  - command: "mix test --exclude=external"
-    label: ":elixir: Unit Tests"
-    env:
-      BUILDKITE_DOCKER: true
-      BUILDKITE_DOCKER_FILE: Dockerfile.ci
-    agents:
-      - docker=1.12.1
-
-  - command: ".buildkite/scripts/integration.sh"
-    label: ":elixir: Integration Tests"
-    env:
-      BUILDKITE_DOCKER_COMPOSE_CONTAINER: cogctl
-      BUILDKITE_DOCKER_COMPOSE_FILE: docker-compose.ci.yml
-    agents:
-      - docker=1.12.1
+  - command: ".buildkite/scripts/select_pipeline.sh"
+    label: "Select :pipeline:"

--- a/.buildkite/scripts/select_pipeline.sh
+++ b/.buildkite/scripts/select_pipeline.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [ -z ${COG_BRANCH+notset} ]
+then
+    PIPELINE=.buildkite/standard_pipeline.yml
+else
+    echo "This is a triggered pipeline; running against the $COG_BRANCH branch of Cog"
+    PIPELINE=.buildkite/triggered_pipeline.yml
+fi
+
+buildkite-agent pipeline upload ${PIPELINE} --replace

--- a/.buildkite/scripts/triggered_integration.sh
+++ b/.buildkite/scripts/triggered_integration.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+echo -e "--- :git: Checking out cog @ branch \033[0;32m${COG_BRANCH}\033[0m"
+rm -Rf local_cog
+git clone --branch=$COG_BRANCH git@github.com:operable/cog.git local_cog
+
+# Buildkite doesn't have native support for multi-file docker-compose
+# runs, so we have to do it ourselves
+
+# Generate a project name like Buildkite does, by removing the hyphens
+# from the job ID
+PROJECT_NAME=cogctl_triggered_${BUILDKITE_JOB_ID//-}
+COMPOSE_ARGS="--file docker-compose.ci.yml --file docker-compose.cog.yml --project-name $PROJECT_NAME"
+
+echo "--- :docker: Building Docker Images"
+docker-compose $COMPOSE_ARGS build --pull
+
+echo "--- :hammer: Running Integration Tests"
+docker-compose $COMPOSE_ARGS run cogctl .buildkite/scripts/integration.sh
+EXIT_STATUS=$?
+if [ $EXIT_STATUS -ne 0 ]
+then
+    echo "--- :skull: The run failed!"
+fi
+
+echo "--- Cleaning up Docker containers"
+# This is what Buildkite does with its native Docker support
+docker-compose $COMPOSE_ARGS kill
+docker-compose $COMPOSE_ARGS rm --force -v
+docker-compose $COMPOSE_ARGS down
+
+exit $EXIT_STATUS

--- a/.buildkite/standard_pipeline.yml
+++ b/.buildkite/standard_pipeline.yml
@@ -1,0 +1,36 @@
+steps:
+  - command: "true"
+    label: ":docker: Build Test Image"
+    # Image compiles test code so it will be cached for other downstream tests
+    env:
+      BUILDKITE_DOCKER: true
+      BUILDKITE_DOCKER_FILE: Dockerfile.ci
+    agents:
+      - docker=1.12.1
+
+  - wait
+
+  - command: "mix escript"
+    label: ":elixir: Escript Build"
+    env:
+      MIX_ENV: prod
+      BUILDKITE_DOCKER: true
+      BUILDKITE_DOCKER_FILE: Dockerfile.ci
+    agents:
+      - docker=1.12.1
+
+  - command: "mix test --exclude=external"
+    label: ":elixir: Unit Tests"
+    env:
+      BUILDKITE_DOCKER: true
+      BUILDKITE_DOCKER_FILE: Dockerfile.ci
+    agents:
+      - docker=1.12.1
+
+  - command: ".buildkite/scripts/integration.sh"
+    label: ":elixir: Integration Tests"
+    env:
+      BUILDKITE_DOCKER_COMPOSE_CONTAINER: cogctl
+      BUILDKITE_DOCKER_COMPOSE_FILE: docker-compose.ci.yml
+    agents:
+      - docker=1.12.1

--- a/.buildkite/triggered_pipeline.yml
+++ b/.buildkite/triggered_pipeline.yml
@@ -1,0 +1,5 @@
+steps:
+  - command: ".buildkite/scripts/triggered_integration.sh"
+    label: ":cogops: Integration Tests Against Cog"
+    agents:
+      - docker=1.12.1

--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ erl_crash.dump
 cogctl
 *.swp
 cogctl.conf
+/local_cog

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ erl_crash.dump
 /cogctl
 *.swp
 cogctl.conf
+/local_cog

--- a/docker-compose.cog.yml
+++ b/docker-compose.cog.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  cog:
+    build:
+      context: ./local_cog
+      dockerfile: Dockerfile


### PR DESCRIPTION
Cog builds now trigger a cogctl pipeline at the end. We now retrieve
the code from the branch of Cog that just built and substitute it for
the `cog-preview` image we would otherwise use.

We can't use Buildkite's built-in Docker Compose support because it
doesn't appear to support layering of compose files, which is what we
need here. As a result, we roll our own support, but using pretty much
the exact same approach that Buildkite takes.

We only bother running the integration tests, because that's what hits
the actual server.

Ideally, we'd also want the "normal" cogctl runs (i.e., not triggered by
cog) to pull from a matching branch (or master), but we can let that
wait until we get the real Dockerfile in cog refactored a bit; right now
the builds for that image can be a bit long, and we can make it shorter.
