### PR TITLE
Use the spanner return values to determine the type of bundle install

### DIFF
--- a/test/cogctl/bundles_test.exs
+++ b/test/cogctl/bundles_test.exs
@@ -65,33 +65,26 @@ defmodule Cogctl.Actions.Bundles.Test do
   test "installing a bundle with stdin" do
     # We create a config file and split it on newlines
     config = BundleHelpers.create_config_str("stdin_test")
-             |> String.split("\n")
-             # We want to split the string on newlines but they should be
-             # include at the end of each line so the yaml parser works properly.
-             |> Enum.map(&(&1 <> "\n"))
 
     # We have to mock stdin bits
-    # First we start up a task to return the config like IO.read would
-    {:ok, pid} = Task.start_link(fn -> stdio_mock(config) end)
-    # Then we mock IO.read
+    {:ok, pid} = StringIO.open(config)
     :meck.new(IO, [:passthrough])
     :meck.expect(IO, :read, fn
                  (:stdio, :line) ->
-                   send(pid, {:read, self()})
-                   receive do
-                     {:line, line} -> line
+                   case :meck.passthrough([pid, :line]) do
                      :eof ->
-                       # We unload the mock after reading the config file
-                       # to prevent clashes with exVCR
+                       # We unload the mock when we get to the end of the file
+                       # so we don't conflict with exVCR
                        :meck.unload(IO)
                        :eof
+                      data ->
+                        data
                    end
-                 (device, line) -> :meck.passthrough(device, line)
+                 (device, line) -> :meck.passthrough([device, line])
     end)
 
     use_cassette "installing_with_stdin", match_requests_on: [:request_body] do
       # assert that we can install a bundle via stdin
-
       assert run("cogctl bundle install -v -i") =~ ~r"""
         Bundle ID:   .*
         Version ID:  .*
@@ -177,18 +170,4 @@ defmodule Cogctl.Actions.Bundles.Test do
       """)
     end
   end
-
-  defp stdio_mock([line | rest]) do
-    receive do
-      {:read, caller} ->
-        send(caller, {:line, line})
-        stdio_mock(rest)
-    end
-  end
-  defp stdio_mock([]) do
-    receive do
-      {:read, caller} -> send(caller, :eof)
-    end
-  end
-
 end

--- a/test/fixtures/cassettes/installing_with_stdin.json
+++ b/test/fixtures/cassettes/installing_with_stdin.json
@@ -1,0 +1,56 @@
+[
+  {
+    "request": {
+      "body": "{\"username\":\"admin\",\"password\":\"iOSpl7(aDyn1xQ.2YGoMEH?6&A<s@LNj\"}",
+      "headers": {
+        "Accept": "application/json",
+        "Content-Type": "application/json"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/token"
+    },
+    "response": {
+      "body": "{\"token\":{\"value\":\"L5NcgfZC4TgvqMqiN1oMseuLgH2uh2WxE4+p59qeLWM=\"}}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 25 Oct 2016 18:20:33 GMT",
+        "content-length": "66",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "7vahkr7bh1q82b5rlhro5fdd3h9a959l"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  },
+  {
+    "request": {
+      "body": "{\"bundle\":{\"force\":false,\"config\":{\"version\":\"0.0.1\",\"name\":\"stdin_test\",\"description\":\"Test bundle\",\"commands\":{\"bar\":{\"rules\":[\"when command is stdin_test:bar allow\"],\"executable\":\"/bin/foobar\"}},\"cog_bundle_version\":4}}}",
+      "headers": {
+        "authorization": "token xoxb-filtered-token",
+        "Accept": "application/json",
+        "Content-Type": "application/json"
+      },
+      "method": "post",
+      "options": [],
+      "request_body": "",
+      "url": "http://localhost:4000/v1/bundles"
+    },
+    "response": {
+      "body": "{\"bundle_version\":{\"version\":\"0.0.1\",\"updated_at\":\"2016-10-25T18:20:34\",\"permissions\":[],\"name\":\"stdin_test\",\"long_description\":null,\"inserted_at\":\"2016-10-25T18:20:34\",\"id\":\"35a6cc4e-bf1a-45b1-9f11-259517863449\",\"homepage\":null,\"enabled\":false,\"description\":\"Test bundle\",\"config_file\":{\"version\":\"0.0.1\",\"name\":\"stdin_test\",\"description\":\"Test bundle\",\"commands\":{\"bar\":{\"rules\":[\"when command is stdin_test:bar allow\"],\"executable\":\"/bin/foobar\"}},\"cog_bundle_version\":4},\"commands\":[{\"rules\":[{\"rule\":\"when command is stdin_test:bar allow\",\"id\":\"bad15c21-2d77-4617-9f24-f82abace4dad\",\"command_name\":\"stdin_test:bar\"}],\"options\":[],\"name\":\"bar\",\"id\":\"f9f5760c-1ee9-4b4d-97c0-285f9974321d\",\"documentation\":null,\"description\":null,\"bundle\":\"stdin_test\"}],\"bundle_id\":\"ccdb789f-9a2f-4e33-a6c0-fd4d2638b881\",\"author\":null}}",
+      "headers": {
+        "server": "Cowboy",
+        "date": "Tue, 25 Oct 2016 18:20:33 GMT",
+        "content-length": "822",
+        "content-type": "application/json; charset=utf-8",
+        "cache-control": "max-age=0, private, must-revalidate",
+        "x-request-id": "sul8mlj9nkfemmb06mlj1ts75npn8a90",
+        "location": "/v1/bundles/ccdb789f-9a2f-4e33-a6c0-fd4d2638b881/versions/35a6cc4e-bf1a-45b1-9f11-259517863449"
+      },
+      "status_code": 201,
+      "type": "ok"
+    }
+  }
+]

--- a/test/support/bundle_helpers.ex
+++ b/test/support/bundle_helpers.ex
@@ -26,7 +26,16 @@ defmodule Support.BundleHelpers do
     File.mkdir_p!(CliHelpers.scratch_dir)
     config_path = Path.join(CliHelpers.scratch_dir, "#{name}.yaml")
 
-    config = """
+    File.write!(config_path, create_config_str(name))
+    config_path
+  end
+
+  @doc """
+  Creates a simple bundle config and returns it as a string
+  """
+  @spec create_config_str(String.t) :: String.t
+  def create_config_str(name) do
+    """
     ---
     name: #{name}
     version: 0.0.1
@@ -38,9 +47,6 @@ defmodule Support.BundleHelpers do
         rules:
         - "allow"
     """
-
-    File.write!(config_path, config)
-    config_path
   end
 
   @doc """


### PR DESCRIPTION
Resolves https://github.com/operable/cog/issues/1065

I'm thinking that the stdin bits could use a test, but I'm at a loss as to how to do it. Any input appreciated, but regardless this should at least fix the bug.