### PR TITLE
Update spanner dependency

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -11,7 +11,7 @@
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []},
   "piper": {:git, "https://github.com/operable/piper.git", "0afedeb326e5ce686daf83a4ed203890e1ad7fe8", []},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "26fffef1486acc37ba4148ce66b0d492feb1b5d1", []},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "60e87c4534d27ef85c84e0cfe7efe5a4a33a5626", []},
   "uuid": {:hex, :uuid, "1.1.3", "06ca38801a1a95b751701ca40716bb97ddf76dfe7e26da0eec7dba636740d57a", [:mix], []},
   "yamerl": {:hex, :yamerl, "0.3.2", "9eac1537d251e926f47763ab1db0d9e6e8f2397646c290d58aa6ceebc6832fb7", [:rebar3], []},
-  "yaml_elixir": {:hex, :yaml_elixir, "1.2.0", "6b7a1d82f00d536831f5f1dfa2aad4f71138059336e513efefdb5f9c20ddb281", [:mix], []}}
+  "yaml_elixir": {:hex, :yaml_elixir, "1.2.1", "4a8ee3b25598100c710ff11dde4d79b6335608ac092d69aab45cc7475b5abc4d", [:mix], [{:yamerl, "~> 0.3.2", [hex: :yamerl, optional: false]}]}}


### PR DESCRIPTION
We just updated the yaml_elixir dependency, and wanted to make sure
this was up-to-date as well.