### PR TITLE
Bump Spanner

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -11,7 +11,7 @@
   "meck": {:hex, :meck, "0.8.4", "59ca1cd971372aa223138efcf9b29475bde299e1953046a0c727184790ab1520", [:rebar, :make], []},
   "piper": {:git, "https://github.com/operable/piper.git", "20995259bba28b0cc30bf1f25e5eeb96441fc48a", []},
   "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
-  "spanner": {:git, "https://github.com/operable/spanner.git", "646eed9a885053d21bb43323e6551518b3b0cec2", []},
+  "spanner": {:git, "https://github.com/operable/spanner.git", "86635b34f4feadcd88105e6cfa04017f6b0a5a76", []},
   "uuid": {:hex, :uuid, "1.1.5", "96cb36d86ee82f912efea4d50464a5df606bf3f1163d6bdbb302d98474969369", [:mix], []},
   "yamerl": {:hex, :yamerl, "0.3.2", "9eac1537d251e926f47763ab1db0d9e6e8f2397646c290d58aa6ceebc6832fb7", [:rebar3], []},
   "yaml_elixir": {:hex, :yaml_elixir, "1.2.1", "4a8ee3b25598100c710ff11dde4d79b6335608ac092d69aab45cc7475b5abc4d", [:mix], [{:yamerl, "~> 0.3.2", [hex: :yamerl, optional: false]}]}}

--- a/test/cogctl_test.exs
+++ b/test/cogctl_test.exs
@@ -11,19 +11,18 @@ defmodule CogctlTest do
     run("cogctl bundles delete #{name}")
 
     # Create some templates
-    Enum.each(["slack", "hipchat"], fn(adapter) ->
-      template_dir = Path.join(@template_dir, adapter)
-      File.mkdir_p!(template_dir)
-
-      Enum.each(["foo", "bar"], &File.write!(Path.join(template_dir, "#{&1}.mustache"), "{{#{&1}}}"))
-    end)
+    File.mkdir_p!(@template_dir)
+    Enum.each(["foo", "bar"],
+              &File.write!(Path.join(@template_dir, "#{&1}.greenbar"),
+                           "Lorem ipsum #{&1}"))
 
     # Create a config file
     config = """
     ---
     name: #{name}
     version: 0.0.1
-    cog_bundle_version: 3
+    cog_bundle_version: 5
+    description: "Does stuff"
     commands:
       bar:
         executable: /bin/foobar
@@ -554,7 +553,8 @@ defmodule CogctlTest do
     bundle_names = Enum.map(1..3, &"bundle#{&1}")
     Enum.each(bundle_names, fn(name) ->
       pre_bundle_create(name)
-      run("cogctl bundle install --templates #{@template_dir} #{Path.join(@scratch_dir, "#{name}.yaml")}")
+      yaml_path = Path.join(@scratch_dir, "#{name}.yaml")
+      run("cogctl bundle install --templates #{@template_dir} #{yaml_path}")
     end)
 
     pre_bundle_create("bundle4")


### PR DESCRIPTION
Removes v3 bundle support; adds v5

Updates the tests to use a v5 testing bundle, too.