### PR TITLE
Tweak cogctl build process

### DIFF
--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 echo "--- :hammer_and_wrench: Build it!"
-scripts/write-git-sha
+scripts/write-git-info
 
 builder_container=cogctl-builder${PLATFORM}-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT}
 docker build \
@@ -16,7 +16,7 @@ docker run \
        --volume "$(pwd)"/dist:/src/dist \
        --rm \
        "${builder_container}" \
-       pyinstaller --onefile --add-data cogctl/GITSHA:. bin/cogctl
+       pyinstaller --onefile --add-data cogctl/GITSHA:. --add-data cogctl/GITTAG:. bin/cogctl
 
 echo "--- :package: Upload artifact"
 package_name=cogctl-${PLATFORM}-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT}

--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -3,22 +3,21 @@
 set -euo pipefail
 
 echo "--- :hammer_and_wrench: Build it!"
-scripts/write-git-info
 
 builder_container=cogctl-builder${PLATFORM}-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT}
 docker build \
        --tag "${builder_container}" \
        --file Dockerfile."${PLATFORM}" .
 
-mkdir dist
+mkdir output
 
 docker run \
-       --volume "$(pwd)"/dist:/src/dist \
+       --volume "$(pwd)"/output:/src/output \
        --rm \
        "${builder_container}" \
-       pyinstaller --onefile --add-data cogctl/GITSHA:. --add-data cogctl/GITTAG:. bin/cogctl
+       cp /usr/bin/cogctl /src/output
 
 echo "--- :package: Upload artifact"
 package_name=cogctl-${PLATFORM}-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT}
-mv dist/cogctl "${package_name}"
+mv output/cogctl "${package_name}"
 buildkite-agent artifact upload "${package_name}"

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-.git
 /_build
 /cover
 /deps

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@ tmp
 bin/*
 !bin/cocgtl
 
-# Generated file for `cogctl version` command
+# Generated files for `cogctl version` command
 cogctl/GITSHA
+cogctl/GITTAG
 
 # Standard Python ignores, as generated at Github
 ########################################################################

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -38,3 +38,5 @@ COPY requirements.txt /src/
 RUN pip3 install -r requirements.txt
 
 COPY . /src/
+RUN cd /src && make build && \
+    cp dist/cogctl /usr/bin

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -38,5 +38,4 @@ COPY requirements.txt /src/
 RUN pip3 install -r requirements.txt
 
 COPY . /src/
-RUN cd /src && make build && \
-    cp dist/cogctl /usr/bin
+RUN make build && cp dist/cogctl /usr/bin

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,7 +1,7 @@
 FROM ubuntu:16.10
 
 RUN apt-get update && \
-    apt-get -y install python3-pip && \
+    apt-get -y install python3-pip git && \
     pip3 install --upgrade pip
 
 WORKDIR /src/
@@ -15,3 +15,5 @@ RUN pip3 install -r requirements.build.txt
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 
 COPY . /src/
+RUN cd /src && make build && \
+    cp dist/cogctl /usr/bin

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -15,5 +15,4 @@ RUN pip3 install -r requirements.build.txt
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 
 COPY . /src/
-RUN cd /src && make build && \
-    cp dist/cogctl /usr/bin
+RUN make build && cp dist/cogctl /usr/bin

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY=build
 build: clean
-	scripts/write-git-sha
-	pyinstaller --onefile --add-data cogctl/GITSHA:. bin/cogctl
+	scripts/write-git-info
+	pyinstaller --onefile --add-data cogctl/GITSHA:. --add-data cogctl/GITTAG:. bin/cogctl
 
 clean:
 	rm -Rf build

--- a/cogctl/__init__.py
+++ b/cogctl/__init__.py
@@ -1,4 +1,2 @@
 # Import decorators here for ease of use
 from cogctl.cli.decorators import error_handler  # noqa: F401
-
-__version__ = '1.0.0-beta'

--- a/cogctl/cli/version.py
+++ b/cogctl/cli/version.py
@@ -9,7 +9,7 @@ def version():
     """
     Display version and build information.
     """
-    version_string = "cogctl %s (build: %s)" % (cogctl.__version__,
+    version_string = "cogctl %s (build: %s)" % (get_build_tag(),
                                                 get_build_version())
     click.echo(version_string)
 
@@ -19,22 +19,39 @@ def get_build_version():
     Return the contents of the file `cogctl/GITSHA`. This is generated
     at build-time and contains the truncated Git SHA of the code being
     built.
+    """
+
+    return _load_bundled_file('GITSHA')
+
+
+def get_build_tag():
+    """
+    Return the contents of the file `cogctl/GITTAG`. This is generated
+    at build-time and contains the Git tag or branch name of the code
+    being built. If no file is found then the string `'dev'` is used.
+    """
+
+    return _load_bundled_file('GITTAG', default='dev')
+
+
+def _load_bundled_file(name, default='unknown'):
+    """
+    Return the contents of a bundled file.
 
     If running in the context of a PyInstaller-built binary, there
     will be a `frozen` attribute on the `sys` module. When running
-    inside such a binary, we'll need to resolve the location of the
-    GITSHA file relative to that bundle.
+    inside such a binary, we'll need to resolve the file's location
+    relative to that bundle.
     """
-
     if getattr(sys, 'frozen', False):
         bundle_dir = sys._MEIPASS
     else:
         bundle_dir = os.path.dirname(cogctl.__file__)
 
-    filename = os.path.join(bundle_dir, 'GITSHA')
+    filename = os.path.join(bundle_dir, name)
 
     if not os.path.exists(filename):
-        return 'unknown'
+        return default
 
     with open(filename) as fh:
         return fh.read().strip()

--- a/cogctl/cli/version.py
+++ b/cogctl/cli/version.py
@@ -21,7 +21,7 @@ def get_build_version():
     built.
     """
 
-    return _load_bundled_file('GITSHA')
+    return _read_bundled_file('GITSHA')
 
 
 def get_build_tag():
@@ -31,10 +31,10 @@ def get_build_tag():
     being built. If no file is found then the string `'dev'` is used.
     """
 
-    return _load_bundled_file('GITTAG', default='dev')
+    return _read_bundled_file('GITTAG', default='dev')
 
 
-def _load_bundled_file(name, default='unknown'):
+def _read_bundled_file(name, default='unknown'):
     """
     Return the contents of a bundled file.
 

--- a/features/version.feature
+++ b/features/version.feature
@@ -6,4 +6,4 @@ Feature: Provide version information
     short Git SHA of the commit from which the binary was built.
 
     When I successfully run `cogctl version`
-    Then the output should match /^cogctl 1.0.0-beta \(build: [a-f0-9]{7}\)/
+    Then the output should match / \(build: [a-f0-9]{7}\)$/

--- a/scripts/write-git-info
+++ b/scripts/write-git-info
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+# Lovingly stolen from docker-compose.
+#
+# Write the current commit sha to the file GITSHA. This file is included in
+# packaging so that `cogctl version` can include the git sha.
+#
+set -e
+git rev-parse --short HEAD > cogctl/GITSHA
+
+
+# Lovingly stolen from go-relay (sort of).
+#
+# Writes the current tag to the file GITTAG. If the current commit
+# isn't tagged then the current branch name is used.
+
+# git describe --tags appends SHA info to
+# prior tag. This subcommand detects when that happens.
+tag=`git describe --tags`
+dash_count=`git describe --tags | grep -o - | wc -l | sed "s/ //g"`
+
+if [ "$dash_count" != "0" ]; then
+  tag=$(git rev-parse --abbrev-ref HEAD)
+fi
+
+echo $tag > cogctl/GITTAG

--- a/scripts/write-git-sha
+++ b/scripts/write-git-sha
@@ -1,9 +1,0 @@
-#!/bin/bash
-#
-# Lovingly stolen from docker-compose.
-#
-# Write the current commit sha to the file GITSHA. This file is included in
-# packaging so that `cogctl version` can include the git sha.
-#
-set -e
-git rev-parse --short HEAD > cogctl/GITSHA


### PR DESCRIPTION
This PR tweaks the cogctl build in two significant ways:

1. `cogctl version` now returns git tag information in additional to commit SHA. The current branch name will be used when building from a untagged commit.
1. Building a Docker image from `Dockerfile.alpine` and `Dockerfile.ubuntu` will also build `/src/dist/cogctl` inside that image. The executable is also copied to `/usr/bin`. This is done to simplify injecting `cogctl` into Cog release builds.