### PR TITLE
Promote master-built images to the cogctl repo

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,8 +25,6 @@ steps:
 
   - wait
 
-  # TODO: Eventually, we'll build this on several platforms, and
-  # package up the results. For now, though, we'll just build
   - label: "Alpine (musl) Build"
     command: ".buildkite/scripts/build.sh"
     env:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -8,6 +8,7 @@ steps:
           - .buildkite/scripts/acceptance.sh
           - .buildkite/scripts/build.sh
           - .buildkite/scripts/run_cucumber.sh
+          - .buildkite/scripts/push_image.sh
 
   - label: "Lint with Flake"
     command: make lint
@@ -49,3 +50,17 @@ steps:
       PLATFORM: ubuntu
       IMAGE: ruby:2.3.3 # <-- technically based on Debian; also actually has python on it (but it's python 2)
                         # Consider building something based on debian:jessie-slim instead
+
+  - wait
+
+  - label: ":docker: Push Alpine Image"
+    command: ".buildkite/scripts/push_image.sh"
+    branches: "master"
+    env:
+      PLATFORM: alpine
+
+  - label: ":docker: Push Ubuntu Image"
+    command: ".buildkite/scripts/push_image.sh"
+    branches: "master"
+    env:
+      PLATFORM: ubuntu

--- a/.buildkite/scripts/build.sh
+++ b/.buildkite/scripts/build.sh
@@ -4,9 +4,12 @@ set -euo pipefail
 
 echo "--- :hammer_and_wrench: Build it!"
 
-builder_container=cogctl-builder${PLATFORM}-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT}
+tag="${PLATFORM}-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT}"
+builder_container="operable/cogctl-testing:${tag}"
+
 docker build \
        --tag "${builder_container}" \
+       --label="git_commit=${BUILDKITE_COMMIT}" \
        --file Dockerfile."${PLATFORM}" .
 
 mkdir output
@@ -21,3 +24,10 @@ echo "--- :package: Upload artifact"
 package_name=cogctl-${PLATFORM}-${BUILDKITE_BUILD_NUMBER}-${BUILDKITE_COMMIT}
 mv output/cogctl "${package_name}"
 buildkite-agent artifact upload "${package_name}"
+
+echo "--- :docker: Pushing ${builder_container}"
+docker push "${builder_container}"
+
+# Set metadata so we can figure out what image to promote to our real
+# repository. See .buildkite/scripts/push_image.sh for more.
+buildkite-agent meta-data set "${PLATFORM}-tag" "${tag}"

--- a/.buildkite/scripts/push_image.sh
+++ b/.buildkite/scripts/push_image.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Promote the platform-specific image we built earlier in the pipeline
+# to our real cogctl Docker repository, tagged as a "master"
+# image. This tag will "float"; only the most recent build will be
+# present, and old builds will go away.
+
+set -euo pipefail
+
+tag=$(buildkite-agent meta-data get "${PLATFORM}-tag")
+
+ci_image="operable/cogctl-testing:${tag}"
+master_image="operable/cogctl:${PLATFORM}-master"
+
+echo "--- Pulling ${ci_image}"
+docker pull "${ci_image}"
+
+echo "--- Re-tagging ${ci_image} to ${master_image}"
+docker tag "${ci_image}" "${master_image}"
+
+echo "--- Pushing  ${master_image}"
+docker push "${master_image}"


### PR DESCRIPTION
To make our current Cog builds easier, we're going to start pulling the
binaries out of the containers we build them in here in CI. (We're
opting for that right now as opposed to setting up some kind of artifact
repository. This is for expediency and incremental improvement; we'll
get an artifact repository soon.)

When we build on the "master" branch, we'll take the built image (which
we now push to our `cogctl-testing` repository, since there's no
guarantee we'll be running on the same agent that built the image in the
first place) and push it to our `cogctl` repository, tagged with both the platform and "master".

This tag will "float" with whatever the current master branch generates;
it will be replaced the next time the build runs. A `git_commit` Docker
label is added to the image, though, which can be used to determine theh
code it came from.
ad9e600
