### PR TITLE
Add --exact-match to tag detection

### DIFF
--- a/scripts/write-git-info
+++ b/scripts/write-git-info
@@ -5,7 +5,6 @@
 # Write the current commit sha to the file GITSHA. This file is included in
 # packaging so that `cogctl version` can include the git sha.
 #
-set -e
 git rev-parse --short HEAD > cogctl/GITSHA
 
 
@@ -13,14 +12,10 @@ git rev-parse --short HEAD > cogctl/GITSHA
 #
 # Writes the current tag to the file GITTAG. If the current commit
 # isn't tagged then the current branch name is used.
-
-# git describe --tags appends SHA info to
-# prior tag. This subcommand detects when that happens.
-tag=`git describe --tags`
-dash_count=`git describe --tags | grep -o - | wc -l | sed "s/ //g"`
-
-if [ "$dash_count" != "0" ]; then
-  tag=$(git rev-parse --abbrev-ref HEAD)
+tag=`git describe --tags --exact-match`
+if [ "$?" != 0 ]
+then
+    tag=$(git rev-parse --abbrev-ref HEAD)
 fi
 
 echo $tag > cogctl/GITTAG


### PR DESCRIPTION
Previously, we relied on the output of `git describe --tags`, which
appends information on how many commits away from the last tag the
current commit is. We subsequently processed this to try and determine
if the output referred directly to a tag. Unfortunately, this would
erroneously filter out tags that contained hyphens.

Now, we add `--exact-match` to the invocation, which will return the
name of the tag the current commit lies on, if indeed it does.

Note that this falls apart if more than one tag point to the current
commit, but with how we tag, that's not likely to occur.